### PR TITLE
Allow binding uniform names to both UBO and Push Constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,6 @@ shaders.
 
 Please report an issue if you run into a shader that works in RetroArch, but not under librashader.
 
-* Variables can only be bound in *either* the UBO or push constant block.
-  * RetroArch allows a variable to be present in both a push constant block and a UBO block at the same time. To make the 
-    implementation a little cleaner, librashader only allows a variable to be in *either* a push constant block or a UBO
-    block. As far as I have tested, there are no shaders in [libretro/slang-shaders](https://github.com/libretro/slang-shaders)
-    that bind the same variable in both the push constant and the UBO block.
 * Filter chains do not terminate at the backbuffer.
   * Unlike RetroArch, librashader does not have full knowledge of the entire rendering state and is designed to be pluggable
     at any point in your render pipeline. Instead, filter chains terminate at a caller-provided output surface and viewport. 

--- a/librashader-reflect/src/error.rs
+++ b/librashader-reflect/src/error.rs
@@ -1,4 +1,4 @@
-use crate::reflect::semantics::{MemberOffset, MemberOffsetType};
+use crate::reflect::semantics::{MemberOffset, UniformMemberBlock};
 use thiserror::Error;
 
 /// Error type for shader compilation.
@@ -81,7 +81,7 @@ pub enum ShaderReflectError {
         semantic: String,
         expected: usize,
         received: usize,
-        ty: MemberOffsetType,
+        ty: UniformMemberBlock,
         pass: usize
     },
     /// The size of the given uniform did not match up in both the vertex and fragment shader.

--- a/librashader-reflect/src/error.rs
+++ b/librashader-reflect/src/error.rs
@@ -1,4 +1,4 @@
-use crate::reflect::semantics::MemberOffset;
+use crate::reflect::semantics::{MemberOffset, MemberOffsetType};
 use thiserror::Error;
 
 /// Error type for shader compilation.
@@ -79,8 +79,10 @@ pub enum ShaderReflectError {
     #[error("mismatched offset")]
     MismatchedOffset {
         semantic: String,
-        vertex: MemberOffset,
-        fragment: MemberOffset,
+        expected: usize,
+        received: usize,
+        ty: MemberOffsetType,
+        pass: usize
     },
     /// The size of the given uniform did not match up in both the vertex and fragment shader.
     #[error("mismatched component")]
@@ -88,6 +90,7 @@ pub enum ShaderReflectError {
         semantic: String,
         vertex: u32,
         fragment: u32,
+        pass: usize
     },
     /// The binding number is already in use.
     #[error("the binding is already in use")]

--- a/librashader-reflect/src/lib.rs
+++ b/librashader-reflect/src/lib.rs
@@ -46,6 +46,7 @@
 //! In the meanwhile, the only supported compilation type is [GlslangCompilation](crate::front::GlslangCompilation),
 //! which does transpilation via [shaderc](https://github.com/google/shaderc) and [SPIRV-Cross](https://github.com/KhronosGroup/SPIRV-Cross).
 #![feature(type_alias_impl_trait)]
+#![feature(let_chains)]
 
 /// Shader codegen backends.
 pub mod back;

--- a/librashader-reflect/src/reflect/cross.rs
+++ b/librashader-reflect/src/reflect/cross.rs
@@ -1,6 +1,6 @@
 use crate::error::{SemanticsErrorKind, ShaderCompileError, ShaderReflectError};
 use crate::front::GlslangCompilation;
-use crate::reflect::semantics::{BindingMeta, BindingStage, MemberOffset, PushReflection, ShaderReflection, ShaderSemantics, TextureBinding, TextureSemanticMap, TextureSemantics, TextureSizeMeta, TypeInfo, UboReflection, UniqueSemanticMap, UniqueSemantics, ValidateTypeSemantics, VariableMeta, MAX_BINDINGS_COUNT, MAX_PUSH_BUFFER_SIZE, MemberOffsetType};
+use crate::reflect::semantics::{BindingMeta, BindingStage, MemberOffset, PushReflection, ShaderReflection, ShaderSemantics, TextureBinding, TextureSemanticMap, TextureSemantics, TextureSizeMeta, TypeInfo, UboReflection, UniqueSemanticMap, UniqueSemantics, ValidateTypeSemantics, VariableMeta, MAX_BINDINGS_COUNT, MAX_PUSH_BUFFER_SIZE, UniformMemberBlock};
 use crate::reflect::{align_uniform_size, ReflectShader};
 use std::ops::Deref;
 
@@ -268,7 +268,7 @@ where
         pass_number: usize,
         semantics: &ShaderSemantics,
         meta: &mut BindingMeta,
-        offset_type: MemberOffsetType,
+        offset_type: UniformMemberBlock,
         blame: SemanticErrorBlame,
     ) -> Result<(), ShaderReflectError> {
         let ranges = ast.get_active_buffer_ranges(resource.id)?;
@@ -620,7 +620,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffsetType::Ubo,
+                UniformMemberBlock::Ubo,
                 SemanticErrorBlame::Vertex,
             )?;
         }
@@ -632,7 +632,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffsetType::Ubo,
+                UniformMemberBlock::Ubo,
                 SemanticErrorBlame::Fragment,
             )?;
         }
@@ -644,7 +644,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffsetType::PushConstant,
+                UniformMemberBlock::PushConstant,
                 SemanticErrorBlame::Vertex,
             )?;
         }
@@ -656,7 +656,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffsetType::PushConstant,
+                UniformMemberBlock::PushConstant,
                 SemanticErrorBlame::Fragment,
             )?;
         }

--- a/librashader-reflect/src/reflect/cross.rs
+++ b/librashader-reflect/src/reflect/cross.rs
@@ -1,11 +1,6 @@
 use crate::error::{SemanticsErrorKind, ShaderCompileError, ShaderReflectError};
 use crate::front::GlslangCompilation;
-use crate::reflect::semantics::{
-    BindingMeta, BindingStage, MemberOffset, PushReflection, ShaderReflection, ShaderSemantics,
-    TextureBinding, TextureSemanticMap, TextureSemantics, TextureSizeMeta, TypeInfo, UboReflection,
-    UniqueSemanticMap, UniqueSemantics, ValidateTypeSemantics, VariableMeta, MAX_BINDINGS_COUNT,
-    MAX_PUSH_BUFFER_SIZE,
-};
+use crate::reflect::semantics::{BindingMeta, BindingStage, MemberOffset, PushReflection, ShaderReflection, ShaderSemantics, TextureBinding, TextureSemanticMap, TextureSemantics, TextureSizeMeta, TypeInfo, UboReflection, UniqueSemanticMap, UniqueSemantics, ValidateTypeSemantics, VariableMeta, MAX_BINDINGS_COUNT, MAX_PUSH_BUFFER_SIZE, MemberOffsetType};
 use crate::reflect::{align_uniform_size, ReflectShader};
 use std::ops::Deref;
 
@@ -273,7 +268,7 @@ where
         pass_number: usize,
         semantics: &ShaderSemantics,
         meta: &mut BindingMeta,
-        offset_type: impl Fn(usize) -> MemberOffset,
+        offset_type: MemberOffsetType,
         blame: SemanticErrorBlame,
     ) -> Result<(), ShaderReflectError> {
         let ranges = ast.get_active_buffer_ranges(resource.id)?;
@@ -298,13 +293,17 @@ where
 
                 match &parameter.semantics {
                     UniqueSemantics::FloatParameter => {
-                        let offset = offset_type(range.offset);
-                        if let Some(meta) = meta.parameter_meta.get(&name) {
-                            if offset != meta.offset {
+                        let offset = range.offset;
+                        if let Some(meta) = meta.parameter_meta.get_mut(&name) {
+                            if let Some(expected) = meta.offset.offset(offset_type)
+                                && expected != offset
+                            {
                                 return Err(ShaderReflectError::MismatchedOffset {
                                     semantic: name,
-                                    vertex: meta.offset,
-                                    fragment: offset,
+                                    expected,
+                                    received: offset,
+                                    ty: offset_type,
+                                    pass: pass_number
                                 });
                             }
                             if meta.size != typeinfo.size {
@@ -312,27 +311,34 @@ where
                                     semantic: name,
                                     vertex: meta.size,
                                     fragment: typeinfo.size,
+                                    pass: pass_number
                                 });
                             }
+
+                            *meta.offset.offset_mut(offset_type) = Some(offset);
                         } else {
                             meta.parameter_meta.insert(
                                 name.clone(),
                                 VariableMeta {
                                     id: name,
-                                    offset,
+                                    offset: MemberOffset::new(offset, offset_type),
                                     size: typeinfo.size,
                                 },
                             );
                         }
                     }
                     semantics => {
-                        let offset = offset_type(range.offset);
-                        if let Some(meta) = meta.unique_meta.get(semantics) {
-                            if offset != meta.offset {
+                        let offset = range.offset;
+                        if let Some(meta) = meta.unique_meta.get_mut(semantics) {
+                            if let Some(expected) = meta.offset.offset(offset_type)
+                                && expected != offset
+                            {
                                 return Err(ShaderReflectError::MismatchedOffset {
                                     semantic: name,
-                                    vertex: meta.offset,
-                                    fragment: offset,
+                                    expected,
+                                    received: offset,
+                                    ty: offset_type,
+                                    pass: pass_number
                                 });
                             }
                             if meta.size != typeinfo.size * typeinfo.columns {
@@ -340,14 +346,17 @@ where
                                     semantic: name,
                                     vertex: meta.size,
                                     fragment: typeinfo.size,
+                                    pass: pass_number
                                 });
                             }
+
+                            *meta.offset.offset_mut(offset_type) = Some(offset);
                         } else {
                             meta.unique_meta.insert(
                                 *semantics,
                                 VariableMeta {
                                     id: name,
-                                    offset,
+                                    offset: MemberOffset::new(offset, offset_type),
                                     size: typeinfo.size * typeinfo.columns,
                                 },
                             );
@@ -368,14 +377,17 @@ where
                     }
                 }
 
-                // this will break if range is both ubo and push buf whatever
-                let offset = offset_type(range.offset);
+                let offset = range.offset;
                 if let Some(meta) = meta.texture_size_meta.get_mut(&texture) {
-                    if offset != meta.offset {
+                    if let Some(expected) = meta.offset.offset(offset_type)
+                        && expected != offset
+                    {
                         return Err(ShaderReflectError::MismatchedOffset {
                             semantic: name,
-                            vertex: meta.offset,
-                            fragment: offset,
+                            expected,
+                            received: offset,
+                            ty: offset_type,
+                            pass: pass_number
                         });
                     }
 
@@ -383,12 +395,13 @@ where
                         SemanticErrorBlame::Vertex => BindingStage::VERTEX,
                         SemanticErrorBlame::Fragment => BindingStage::FRAGMENT,
                     });
+
+                    *meta.offset.offset_mut(offset_type) = Some(offset);
                 } else {
                     meta.texture_size_meta.insert(
                         texture,
                         TextureSizeMeta {
-                            offset,
-                            // todo: fix this. to allow both
+                            offset: MemberOffset::new(offset, offset_type),
                             stage_mask: match blame {
                                 SemanticErrorBlame::Vertex => BindingStage::VERTEX,
                                 SemanticErrorBlame::Fragment => BindingStage::FRAGMENT,
@@ -607,7 +620,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffset::Ubo,
+                MemberOffsetType::Ubo,
                 SemanticErrorBlame::Vertex,
             )?;
         }
@@ -619,7 +632,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffset::Ubo,
+                MemberOffsetType::Ubo,
                 SemanticErrorBlame::Fragment,
             )?;
         }
@@ -631,7 +644,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffset::PushConstant,
+                MemberOffsetType::PushConstant,
                 SemanticErrorBlame::Vertex,
             )?;
         }
@@ -643,7 +656,7 @@ where
                 pass_number,
                 semantics,
                 &mut meta,
-                MemberOffset::PushConstant,
+                MemberOffsetType::PushConstant,
                 SemanticErrorBlame::Fragment,
             )?;
         }

--- a/librashader-reflect/src/reflect/semantics.rs
+++ b/librashader-reflect/src/reflect/semantics.rs
@@ -194,11 +194,54 @@ pub struct PushReflection {
 /// A uniform can be bound to **either** the UBO, or as a Push Constant. Binding
 /// the same variable name to both locations will result in indeterminate results.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum MemberOffset {
+pub struct MemberOffset {
     /// The offset of the uniform member within the UBO.
-    Ubo(usize),
+    pub ubo: Option<usize>,
     /// The offset of the uniform member within the Push Constant range.
-    PushConstant(usize),
+    pub push: Option<usize>,
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The type of member offset available.
+pub enum MemberOffsetType {
+    /// The offset is for a UBO.
+    Ubo,
+    /// The offset is for a push constant block.
+    PushConstant
+}
+
+impl MemberOffset {
+    pub(crate) fn new(off: usize, ty: MemberOffsetType) -> Self {
+        match ty {
+            MemberOffsetType::Ubo => {
+                MemberOffset {
+                    ubo: Some(off),
+                    push: None,
+                }
+            }
+            MemberOffsetType::PushConstant => {
+                MemberOffset {
+                    ubo: None,
+                    push: Some(off),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn offset(&self, ty: MemberOffsetType) -> Option<usize> {
+        match ty {
+            MemberOffsetType::Ubo => {self.ubo}
+            MemberOffsetType::PushConstant => {self.push}
+        }
+    }
+
+    pub(crate) fn offset_mut(&mut self, ty: MemberOffsetType) -> &mut Option<usize> {
+        match ty {
+            MemberOffsetType::Ubo => {&mut self.ubo}
+            MemberOffsetType::PushConstant => {&mut self.push}
+        }
+    }
 }
 
 /// Reflection information about a non-texture related uniform variable.

--- a/librashader-reflect/src/reflect/semantics.rs
+++ b/librashader-reflect/src/reflect/semantics.rs
@@ -203,24 +203,29 @@ pub struct MemberOffset {
 
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// The type of member offset available.
-pub enum MemberOffsetType {
+/// The block where a uniform member is located.
+pub enum UniformMemberBlock {
     /// The offset is for a UBO.
     Ubo,
     /// The offset is for a push constant block.
     PushConstant
 }
 
+impl UniformMemberBlock {
+    /// A list of valid member block types.
+    pub const TYPES: [UniformMemberBlock; 2] = [UniformMemberBlock::Ubo, UniformMemberBlock::PushConstant];
+}
+
 impl MemberOffset {
-    pub(crate) fn new(off: usize, ty: MemberOffsetType) -> Self {
+    pub(crate) fn new(off: usize, ty: UniformMemberBlock) -> Self {
         match ty {
-            MemberOffsetType::Ubo => {
+            UniformMemberBlock::Ubo => {
                 MemberOffset {
                     ubo: Some(off),
                     push: None,
                 }
             }
-            MemberOffsetType::PushConstant => {
+            UniformMemberBlock::PushConstant => {
                 MemberOffset {
                     ubo: None,
                     push: Some(off),
@@ -229,17 +234,17 @@ impl MemberOffset {
         }
     }
 
-    pub(crate) fn offset(&self, ty: MemberOffsetType) -> Option<usize> {
+    pub fn offset(&self, ty: UniformMemberBlock) -> Option<usize> {
         match ty {
-            MemberOffsetType::Ubo => {self.ubo}
-            MemberOffsetType::PushConstant => {self.push}
+            UniformMemberBlock::Ubo => {self.ubo}
+            UniformMemberBlock::PushConstant => {self.push}
         }
     }
 
-    pub(crate) fn offset_mut(&mut self, ty: MemberOffsetType) -> &mut Option<usize> {
+    pub(crate) fn offset_mut(&mut self, ty: UniformMemberBlock) -> &mut Option<usize> {
         match ty {
-            MemberOffsetType::Ubo => {&mut self.ubo}
-            MemberOffsetType::PushConstant => {&mut self.push}
+            UniformMemberBlock::Ubo => {&mut self.ubo}
+            UniformMemberBlock::PushConstant => {&mut self.push}
         }
     }
 }

--- a/librashader-runtime-d3d11/src/lib.rs
+++ b/librashader-runtime-d3d11/src/lib.rs
@@ -33,7 +33,8 @@ mod tests {
     #[test]
     fn triangle_d3d11() {
         let sample = hello_triangle::d3d11_hello_triangle::Sample::new(
-            "../test/slang-shaders/presets/crt-royale-kurozumi.slangp",
+            // "../test/slang-shaders/presets/crt-royale-kurozumi.slangp",
+            "../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             // "../test/basic.slangp",
             Some(&FilterChainOptionsD3D11 {
                 use_deferred_context: false,

--- a/librashader-runtime-gl/src/filter_pass.rs
+++ b/librashader-runtime-gl/src/filter_pass.rs
@@ -48,17 +48,17 @@ impl TextureInput for InputTexture {
     }
 }
 
-impl ContextOffset<GlUniformBinder, UniformLocation<GLint>> for UniformOffset {
+impl ContextOffset<GlUniformBinder, VariableLocation> for UniformOffset {
     fn offset(&self) -> MemberOffset {
         self.offset
     }
 
-    fn context(&self) -> UniformLocation<GLint> {
-        self.location.location()
+    fn context(&self) -> VariableLocation {
+        self.location
     }
 }
 
-impl<T: GLInterface> BindSemantics<GlUniformBinder, UniformLocation<GLint>> for FilterPass<T> {
+impl<T: GLInterface> BindSemantics<GlUniformBinder, VariableLocation> for FilterPass<T> {
     type InputTexture = InputTexture;
     type SamplerSet = SamplerSet;
     type DescriptorSet<'a> = ();

--- a/librashader-runtime-gl/src/lib.rs
+++ b/librashader-runtime-gl/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(strict_provenance)]
 #![feature(type_alias_impl_trait)]
 #![feature(let_chains)]
+#![feature(is_some_and)]
 
 mod binding;
 mod filter_chain;
@@ -35,7 +36,7 @@ mod tests {
     fn triangle_gl() {
         let (glfw, window, events, shader, vao) = gl::gl3::hello_triangle::setup();
         let mut filter = FilterChainGL::load_from_path(
-            "../test/slang-shaders/crt/crt-lottes.slangp",
+            "../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             Some(&FilterChainOptionsGL {
                 gl_version: 0,
                 use_dsa: false,

--- a/librashader-runtime/src/binding.rs
+++ b/librashader-runtime/src/binding.rs
@@ -50,6 +50,7 @@ where
 /// Trait that abstracts binding of semantics to shader uniforms.
 pub trait BindSemantics<H = NoUniformBinder, C = Option<()>, S = Box<[u8]>>
 where
+    C: Copy,
     S: Deref<Target = [u8]> + DerefMut,
     H: BindUniform<C, f32>,
     H: BindUniform<C, u32>,


### PR DESCRIPTION
Some shaders do really funky shit and bind the same variable name to the UBO and PCB accessed in different stages. This allows for a uniform to be bound to both the UBO and PCB to fix these edge cases.