### PR TITLE
capi: emit delayload link arg for D3D12 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Please report an issue if you run into a shader that works in RetroArch, but not
     which was released in late 2018.
   * For maximum compatibility with shaders, a shader compile pipeline based on [`spirv-to-dxil`](https://github.com/SnowflakePowered/spirv-to-dxil-rs) is used, with the SPIRV-Cross HLSL pipeline used as a fallback. 
     This brings shader compatibility beyond what the RetroArch Direct3D 12 driver provides. The HLSL pipeline fallback may be removed in the future as `spirv-to-dxil` improves.
+  * The Direct3D 12 runtime requires `dxil.dll` and `dxcompiler.dll` from the [DirectX Shader Compiler](https://github.com/microsoft/DirectXShaderCompiler).
 
 Most, if not all shader presets should work fine on librashader. The runtime specific differences should not affect the output,
 and are more a heads-up for integrating librashader into your project.

--- a/librashader-capi/build.rs
+++ b/librashader-capi/build.rs
@@ -1,0 +1,8 @@
+pub fn main() {
+    #[cfg(all(target_os = "windows", feature = "runtime-d3d12"))]
+    {
+        println!("cargo:rustc-link-lib=dylib=delayimp");
+        println!("cargo:rustc-link-arg=/DELAYLOAD:dxcompiler.dll");
+        println!("cargo:rustc-link-arg=/DELAYLOAD:d3d12.dll");
+    }
+}


### PR DESCRIPTION
Will ensure D3D12 DLL dependencies are not loaded for non-D3D12 environments