### PR TITLE
d3d11/12: fix sampler set creation

### DIFF
--- a/librashader-runtime-d3d11/src/samplers.rs
+++ b/librashader-runtime-d3d11/src/samplers.rs
@@ -31,7 +31,7 @@ impl SamplerSet {
                     let mut sampler = None;
                     device.CreateSamplerState(
                         &D3D11_SAMPLER_DESC {
-                            Filter: FilterMode::Linear.into(),
+                            Filter: filter_mode.into(),
                             AddressU: D3D11_TEXTURE_ADDRESS_MODE::from(*wrap_mode),
                             AddressV: D3D11_TEXTURE_ADDRESS_MODE::from(*wrap_mode),
                             AddressW: D3D11_TEXTURE_ADDRESS_MODE::from(*wrap_mode),

--- a/librashader-runtime-d3d12/src/samplers.rs
+++ b/librashader-runtime-d3d12/src/samplers.rs
@@ -41,7 +41,7 @@ impl SamplerSet {
                     let sampler = heap.alloc_slot()?;
                     device.CreateSampler(
                         &D3D12_SAMPLER_DESC {
-                            Filter: FilterMode::Linear.into(),
+                            Filter: filter_mode.into(),
                             AddressU: D3D12_TEXTURE_ADDRESS_MODE::from(*wrap_mode),
                             AddressV: D3D12_TEXTURE_ADDRESS_MODE::from(*wrap_mode),
                             AddressW: D3D12_TEXTURE_ADDRESS_MODE::from(*wrap_mode),


### PR DESCRIPTION
Regression from 8ed244f6faee3ccd5520269033f5a17bd5c0c467