### PR TITLE
opengl + other runtime fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1685,6 +1685,7 @@ dependencies = [
 name = "librashader-runtime-vk"
 version = "0.2.0-beta.9"
 dependencies = [
+ "array-concat",
  "ash",
  "ash-window",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "concat-arrays"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df715824eb382e34b7afb7463b0247bf41538aeba731fba05241ecdb5dc3747"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1677,7 @@ name = "librashader-runtime-gl"
 version = "0.2.0-beta.9"
 dependencies = [
  "bytemuck",
+ "concat-arrays",
  "gl",
  "glfw 0.47.0",
  "librashader-cache",

--- a/librashader-reflect/src/reflect/cross/glsl.rs
+++ b/librashader-reflect/src/reflect/cross/glsl.rs
@@ -28,9 +28,6 @@ impl CompileShader<GLSL> for CrossReflect<spirv_cross::glsl::Target> {
         let vertex_resources = self.vertex.get_shader_resources()?;
         let fragment_resources = self.fragment.get_shader_resources()?;
 
-        for res in &vertex_resources.stage_inputs {
-            self.vertex.unset_decoration(res.id, Decoration::Location)?;
-        }
         for res in &vertex_resources.stage_outputs {
             // let location = self.vertex.get_decoration(res.id, Decoration::Location)?;
             // self.vertex

--- a/librashader-reflect/src/reflect/cross/msl.rs
+++ b/librashader-reflect/src/reflect/cross/msl.rs
@@ -149,6 +149,6 @@ mod test {
 
         let compiled = msl.compile(Some(msl::Version::V2_0)).unwrap();
 
-        println!("{}", compiled.fragment);
+        println!("{}", compiled.vertex);
     }
 }

--- a/librashader-reflect/src/reflect/naga/msl.rs
+++ b/librashader-reflect/src/reflect/naga/msl.rs
@@ -196,6 +196,6 @@ mod test {
 
         let compiled = msl.compile(Some(msl::Version::V2_0)).unwrap();
 
-        println!("{}", compiled.fragment);
+        println!("{:?}", compiled.context.fragment.translation_info.entry_point_names);
     }
 }

--- a/librashader-reflect/src/reflect/naga/msl.rs
+++ b/librashader-reflect/src/reflect/naga/msl.rs
@@ -196,6 +196,9 @@ mod test {
 
         let compiled = msl.compile(Some(msl::Version::V2_0)).unwrap();
 
-        println!("{:?}", compiled.context.fragment.translation_info.entry_point_names);
+        println!(
+            "{:?}",
+            compiled.context.fragment.translation_info.entry_point_names
+        );
     }
 }

--- a/librashader-runtime-gl/Cargo.toml
+++ b/librashader-runtime-gl/Cargo.toml
@@ -22,9 +22,10 @@ spirv_cross = { package = "librashader-spirv-cross", version = "0.24" }
 
 rustc-hash = "1.1.0"
 gl = "0.14.0"
-bytemuck = "1.12.3"
+bytemuck = { version = "1.12.3", features = ["derive"] }
 thiserror = "1.0.37"
 rayon = "1.6.1"
+concat-arrays = "0.1.2"
 
 sptr = "0.3"
 

--- a/librashader-runtime-gl/src/gl/gl3/draw_quad.rs
+++ b/librashader-runtime-gl/src/gl/gl3/draw_quad.rs
@@ -1,13 +1,7 @@
-use crate::gl::DrawQuad;
+use crate::gl::FINAL_VBO_DATA;
+use crate::gl::{DrawQuad, OpenGLVertex};
 use gl::types::{GLsizei, GLsizeiptr, GLuint};
-
-#[rustfmt::skip]
-static QUAD_VBO_DATA: &[f32; 16] = &[
-    0.0, 0.0, 0.0, 0.0,
-    1.0, 0.0, 1.0, 0.0,
-    0.0, 1.0, 0.0, 1.0,
-    1.0, 1.0, 1.0, 1.0,
-];
+use std::mem::offset_of;
 
 pub struct Gl3DrawQuad {
     vbo: GLuint,
@@ -24,8 +18,8 @@ impl DrawQuad for Gl3DrawQuad {
             gl::BindBuffer(gl::ARRAY_BUFFER, vbo);
             gl::BufferData(
                 gl::ARRAY_BUFFER,
-                std::mem::size_of_val(QUAD_VBO_DATA) as GLsizeiptr,
-                QUAD_VBO_DATA.as_ptr().cast(),
+                4 * std::mem::size_of::<OpenGLVertex>() as GLsizeiptr,
+                FINAL_VBO_DATA.as_ptr().cast(),
                 gl::STATIC_DRAW,
             );
             gl::BindBuffer(gl::ARRAY_BUFFER, 0);
@@ -51,16 +45,16 @@ impl DrawQuad for Gl3DrawQuad {
                 2,
                 gl::FLOAT,
                 gl::FALSE,
-                (4 * std::mem::size_of::<f32>()) as GLsizei,
-                sptr::invalid(0),
+                std::mem::size_of::<OpenGLVertex>() as GLsizei,
+                sptr::invalid(offset_of!(OpenGLVertex, position)),
             );
             gl::VertexAttribPointer(
                 1,
                 2,
                 gl::FLOAT,
                 gl::FALSE,
-                (4 * std::mem::size_of::<f32>()) as GLsizei,
-                sptr::invalid(2 * std::mem::size_of::<f32>()),
+                std::mem::size_of::<OpenGLVertex>() as GLsizei,
+                sptr::invalid(offset_of!(OpenGLVertex, position)),
             );
         }
     }

--- a/librashader-runtime-gl/src/gl/gl46/draw_quad.rs
+++ b/librashader-runtime-gl/src/gl/gl46/draw_quad.rs
@@ -1,14 +1,7 @@
-use crate::gl::DrawQuad;
+use crate::gl::FINAL_VBO_DATA;
+use crate::gl::{DrawQuad, OpenGLVertex};
 use gl::types::{GLint, GLsizeiptr, GLuint};
-
-#[rustfmt::skip]
-static QUAD_VBO_DATA: &[f32; 16] = &[
-    0.0, 0.0, 0.0, 0.0,
-    1.0, 0.0, 1.0, 0.0,
-    0.0, 1.0, 0.0, 1.0,
-    1.0, 1.0, 1.0, 1.0,
-];
-
+use std::mem::offset_of;
 pub struct Gl46DrawQuad {
     vbo: GLuint,
     vao: GLuint,
@@ -23,8 +16,8 @@ impl DrawQuad for Gl46DrawQuad {
             gl::CreateBuffers(1, &mut vbo);
             gl::NamedBufferData(
                 vbo,
-                std::mem::size_of_val(QUAD_VBO_DATA) as GLsizeiptr,
-                QUAD_VBO_DATA.as_ptr().cast(),
+                4 * std::mem::size_of::<OpenGLVertex>() as GLsizeiptr,
+                FINAL_VBO_DATA.as_ptr().cast(),
                 gl::STATIC_DRAW,
             );
             gl::CreateVertexArrays(1, &mut vao);
@@ -32,16 +25,29 @@ impl DrawQuad for Gl46DrawQuad {
             gl::EnableVertexArrayAttrib(vao, 0);
             gl::EnableVertexArrayAttrib(vao, 1);
 
-            gl::VertexArrayVertexBuffer(vao, 0, vbo, 0, 4 * std::mem::size_of::<f32>() as GLint);
+            gl::VertexArrayVertexBuffer(
+                vao,
+                0,
+                vbo,
+                0,
+                std::mem::size_of::<OpenGLVertex>() as GLint,
+            );
 
-            gl::VertexArrayAttribFormat(vao, 0, 2, gl::FLOAT, gl::FALSE, 0);
+            gl::VertexArrayAttribFormat(
+                vao,
+                0,
+                2,
+                gl::FLOAT,
+                gl::FALSE,
+                offset_of!(OpenGLVertex, position) as GLuint,
+            );
             gl::VertexArrayAttribFormat(
                 vao,
                 1,
                 2,
                 gl::FLOAT,
                 gl::FALSE,
-                2 * std::mem::size_of::<f32>() as GLuint,
+                offset_of!(OpenGLVertex, texcoord) as GLuint,
             );
 
             gl::VertexArrayAttribBinding(vao, 0, 0);

--- a/librashader-runtime-gl/src/gl/mod.rs
+++ b/librashader-runtime-gl/src/gl/mod.rs
@@ -7,6 +7,7 @@ use crate::error::Result;
 use crate::framebuffer::GLImage;
 use crate::samplers::SamplerSet;
 use crate::texture::InputTexture;
+use bytemuck::{Pod, Zeroable};
 pub use framebuffer::GLFramebuffer;
 use gl::types::{GLenum, GLuint};
 use librashader_common::{ImageFormat, Size};
@@ -16,6 +17,33 @@ use librashader_reflect::back::ShaderCompilerOutput;
 use librashader_reflect::reflect::semantics::{BufferReflection, TextureBinding};
 use librashader_runtime::uniforms::UniformStorageAccess;
 use rustc_hash::FxHashMap;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Default, Zeroable, Pod)]
+
+pub(crate) struct OpenGLVertex {
+    pub position: [f32; 2],
+    pub texcoord: [f32; 2],
+}
+
+pub(crate) static FINAL_VBO_DATA: &[OpenGLVertex; 4] = &[
+    OpenGLVertex {
+        position: [0.0, 0.0],
+        texcoord: [0.0, 0.0],
+    },
+    OpenGLVertex {
+        position: [1.0, 0.0],
+        texcoord: [1.0, 0.0],
+    },
+    OpenGLVertex {
+        position: [0.0, 1.0],
+        texcoord: [0.0, 1.0],
+    },
+    OpenGLVertex {
+        position: [1.0, 1.0],
+        texcoord: [1.0, 1.0],
+    },
+];
 
 pub(crate) trait LoadLut {
     fn load_luts(textures: &[TextureConfig]) -> Result<FxHashMap<usize, InputTexture>>;

--- a/librashader-runtime-gl/tests/hello_triangle/gl3.rs
+++ b/librashader-runtime-gl/tests/hello_triangle/gl3.rs
@@ -174,14 +174,14 @@ void main()
 }";
     let shader_program = compile_program(VERT_SHADER, FRAG_SHADER);
 
-    unsafe {
-        gl::ObjectLabel(
-            gl::SHADER,
-            shader_program,
-            -1,
-            b"color_shader\0".as_ptr().cast(),
-        );
-    }
+    // unsafe {
+    //     gl::ObjectLabel(
+    //         gl::SHADER,
+    //         shader_program,
+    //         -1,
+    //         b"color_shader\0".as_ptr().cast(),
+    //     );
+    // }
 
     let vertices = &[
         // positions      // colors
@@ -192,7 +192,7 @@ void main()
     let mut vbo: gl::types::GLuint = 0;
     unsafe {
         gl::GenBuffers(1, &mut vbo);
-        gl::ObjectLabel(gl::BUFFER, vbo, -1, b"triangle_vbo\0".as_ptr().cast());
+        // gl::ObjectLabel(gl::BUFFER, vbo, -1, b"triangle_vbo\0".as_ptr().cast());
     }
 
     unsafe {
@@ -211,7 +211,7 @@ void main()
     let mut vao: gl::types::GLuint = 0;
     unsafe {
         gl::GenVertexArrays(1, &mut vao);
-        gl::ObjectLabel(gl::VERTEX_ARRAY, vao, -1, b"triangle_vao\0".as_ptr().cast());
+        // gl::ObjectLabel(gl::VERTEX_ARRAY, vao, -1, b"triangle_vao\0".as_ptr().cast());
     }
 
     unsafe {
@@ -280,23 +280,23 @@ pub fn do_loop(
         gl::GenFramebuffers(1, &mut rendered_framebuffer);
         gl::BindFramebuffer(gl::FRAMEBUFFER, rendered_framebuffer);
 
-        gl::ObjectLabel(
-            gl::FRAMEBUFFER,
-            rendered_framebuffer,
-            -1,
-            b"rendered_framebuffer\0".as_ptr().cast(),
-        );
+        // gl::ObjectLabel(
+        //     gl::FRAMEBUFFER,
+        //     rendered_framebuffer,
+        //     -1,
+        //     b"rendered_framebuffer\0".as_ptr().cast(),
+        // );
 
         // make tetxure
         gl::GenTextures(1, &mut rendered_texture);
         gl::BindTexture(gl::TEXTURE_2D, rendered_texture);
 
-        gl::ObjectLabel(
-            gl::TEXTURE,
-            rendered_texture,
-            -1,
-            b"rendered_texture\0".as_ptr().cast(),
-        );
+        // gl::ObjectLabel(
+        //     gl::TEXTURE,
+        //     rendered_texture,
+        //     -1,
+        //     b"rendered_texture\0".as_ptr().cast(),
+        // );
 
         // empty image
         gl::TexStorage2D(
@@ -356,23 +356,23 @@ pub fn do_loop(
         gl::GenFramebuffers(1, &mut output_framebuffer_handle);
         gl::BindFramebuffer(gl::FRAMEBUFFER, output_framebuffer_handle);
 
-        gl::ObjectLabel(
-            gl::FRAMEBUFFER,
-            output_framebuffer_handle,
-            -1,
-            b"output_framebuffer\0".as_ptr().cast(),
-        );
+        // gl::ObjectLabel(
+        //     gl::FRAMEBUFFER,
+        //     output_framebuffer_handle,
+        //     -1,
+        //     b"output_framebuffer\0".as_ptr().cast(),
+        // );
 
         // make tetxure
         gl::GenTextures(1, &mut output_texture);
         gl::BindTexture(gl::TEXTURE_2D, output_texture);
 
-        gl::ObjectLabel(
-            gl::TEXTURE,
-            output_texture,
-            -1,
-            b"output_texture\0".as_ptr().cast(),
-        );
+        // gl::ObjectLabel(
+        //     gl::TEXTURE,
+        //     output_texture,
+        //     -1,
+        //     b"output_texture\0".as_ptr().cast(),
+        // );
 
         // empty image
         gl::TexStorage2D(

--- a/librashader-runtime-gl/tests/triangle.rs
+++ b/librashader-runtime-gl/tests/triangle.rs
@@ -9,7 +9,7 @@ fn triangle_gl() {
 
     unsafe {
         let mut filter = FilterChainGL::load_from_path(
-            "../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
+            "../test/shaders_slang/crt/crt-royale.slangp",
             Some(&FilterChainOptionsGL {
                 glsl_version: 0,
                 use_dsa: false,
@@ -30,7 +30,7 @@ fn triangle_gl46() {
         let mut filter = FilterChainGL::load_from_path(
             // "../test/slang-shaders/vhs/VHSPro.slangp",
             // "../test/slang-shaders/test/history.slangp",
-            "../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
+            "../test/shaders_slang/crt/crt-royale.slangp",
             // "../test/shadersslang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             Some(&FilterChainOptionsGL {
                 glsl_version: 0,

--- a/librashader-runtime-vk/Cargo.toml
+++ b/librashader-runtime-vk/Cargo.toml
@@ -22,12 +22,13 @@ librashader-runtime = { path = "../librashader-runtime" , version = "0.2.0-beta.
 librashader-cache = { path = "../librashader-cache", version = "0.2.0-beta.9" }
 
 rustc-hash = "1.1.0"
-bytemuck = "1.12.3"
+bytemuck = { version = "1.12.3", features = ["derive"] }
 thiserror = "1.0.37"
 ash = { version = "0.37", features = ["debug"] }
 gpu-allocator = { version = "0.22.0", default-features = false, features = ["vulkan"] }
 parking_lot = "0.12.1"
 rayon = "1.6.1"
+array-concat = "0.5.2"
 
 [dev-dependencies]
 num = "0.4.0"

--- a/librashader-runtime-vk/src/draw_quad.rs
+++ b/librashader-runtime-vk/src/draw_quad.rs
@@ -1,12 +1,12 @@
 use crate::error;
 use crate::memory::VulkanBuffer;
+use array_concat::concat_arrays;
 use ash::vk;
+use bytemuck::{Pod, Zeroable};
 use gpu_allocator::vulkan::Allocator;
 use librashader_runtime::quad::QuadType;
 use parking_lot::RwLock;
 use std::sync::Arc;
-use bytemuck::{Pod, Zeroable};
-use array_concat::concat_arrays;
 
 // Vulkan does vertex expansion
 #[repr(C)]
@@ -75,8 +75,7 @@ impl DrawQuad {
 
         {
             let slice = buffer.as_mut_slice()?;
-            slice
-                .copy_from_slice(bytemuck::cast_slice(VBO_DATA));
+            slice.copy_from_slice(bytemuck::cast_slice(VBO_DATA));
         }
 
         Ok(DrawQuad {


### PR DESCRIPTION
* don't unset vertex inputs attribs when compiling glsl
* use structs for quad data rather than [f32;16]