### PR TITLE
vk: remove unneeded device arcs

### DIFF
--- a/librashader-runtime-vk/src/draw_quad.rs
+++ b/librashader-runtime-vk/src/draw_quad.rs
@@ -49,7 +49,6 @@ static VBO_DATA: &[VertexInput; 8] = &concat_arrays!(OFFSCREEN_VBO_DATA, FINAL_V
 
 pub struct DrawQuad {
     buffer: VulkanBuffer,
-    device: Arc<ash::Device>,
 }
 
 impl DrawQuad {
@@ -69,31 +68,23 @@ impl DrawQuad {
             slice.copy_from_slice(bytemuck::cast_slice(VBO_DATA));
         }
 
-        Ok(DrawQuad {
-            buffer,
-            device: device.clone(),
-        })
+        Ok(DrawQuad { buffer })
     }
 
-    pub fn bind_vbo_for_frame(&self, cmd: vk::CommandBuffer) {
+    pub fn bind_vbo_for_frame(&self, device: &ash::Device, cmd: vk::CommandBuffer) {
         unsafe {
-            self.device.cmd_bind_vertex_buffers(
-                cmd,
-                0,
-                &[self.buffer.handle],
-                &[0 as vk::DeviceSize],
-            )
+            device.cmd_bind_vertex_buffers(cmd, 0, &[self.buffer.handle], &[0 as vk::DeviceSize])
         }
     }
 
-    pub fn draw_quad(&self, cmd: vk::CommandBuffer, vbo: QuadType) {
+    pub fn draw_quad(&self, device: &ash::Device, cmd: vk::CommandBuffer, vbo: QuadType) {
         let offset = match vbo {
             QuadType::Offscreen => 0,
             QuadType::Final => 4,
         };
 
         unsafe {
-            self.device.cmd_draw(cmd, 4, 1, offset, 0);
+            device.cmd_draw(cmd, 4, 1, offset, 0);
         }
     }
 }

--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -459,7 +459,6 @@ impl FilterChainVulkan {
                 )?;
 
                 Ok(FilterPass {
-                    device: vulkan.device.clone(),
                     reflection,
                     // compiled: spirv_words,
                     uniform_storage,
@@ -670,14 +669,16 @@ impl FilterChainVulkan {
 
         let options = options.unwrap_or(&self.default_options);
 
-        self.common.draw_quad.bind_vbo_for_frame(cmd);
+        self.common
+            .draw_quad
+            .bind_vbo_for_frame(&self.vulkan.device, cmd);
         for (index, pass) in pass.iter_mut().enumerate() {
             let target = &self.output_framebuffers[index];
             source.filter_mode = pass.config.filter;
             source.wrap_mode = pass.config.wrap_mode;
             source.mip_filter = pass.config.filter;
 
-            let output_image = OutputImage::new(&self.vulkan, target.image.clone())?;
+            let output_image = OutputImage::new(&self.vulkan.device, target.image.clone())?;
             let out = RenderTarget::identity(&output_image);
 
             let residual_fb = pass.draw(
@@ -696,7 +697,7 @@ impl FilterChainVulkan {
             if target.max_miplevels > 1 && !self.disable_mipmaps {
                 target.generate_mipmaps_and_end_pass(cmd);
             } else {
-                out.output.end_pass(cmd);
+                out.output.end_pass(&self.vulkan.device, cmd);
             }
 
             source = self.common.output_textures[index].clone().unwrap();
@@ -722,7 +723,7 @@ impl FilterChainVulkan {
             source.wrap_mode = pass.config.wrap_mode;
             source.mip_filter = pass.config.filter;
 
-            let output_image = OutputImage::new(&self.vulkan, viewport.output.clone())?;
+            let output_image = OutputImage::new(&self.vulkan.device, viewport.output.clone())?;
             let out = RenderTarget::viewport_with_output(&output_image, viewport);
 
             let residual_fb = pass.draw(


### PR DESCRIPTION
Anything that isn't `Drop` doesn't need to hold on to a `device`.