### PR TITLE
deps: upgrade to windows 0.52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ dependencies = [
  "rayon",
  "wgpu",
  "wgpu-types",
- "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ dependencies = [
  "platform-dirs",
  "serde",
  "thiserror",
- "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ dependencies = [
  "rustc-hash",
  "sptr",
  "thiserror",
- "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ dependencies = [
  "num-traits",
  "rustc-hash",
  "wgpu-types",
- "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1621,6 +1621,7 @@ dependencies = [
  "rayon",
  "thiserror",
  "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -1644,6 +1645,7 @@ dependencies = [
  "thiserror",
  "widestring",
  "windows 0.48.0",
+ "windows 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
  "presser",
  "thiserror",
  "winapi",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ dependencies = [
  "rayon",
  "wgpu",
  "wgpu-types",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1506,7 +1506,7 @@ dependencies = [
  "platform-dirs",
  "serde",
  "thiserror",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1523,7 +1523,7 @@ dependencies = [
  "rustc-hash",
  "sptr",
  "thiserror",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ dependencies = [
  "num-traits",
  "rustc-hash",
  "wgpu-types",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1620,8 +1620,7 @@ dependencies = [
  "librashader-runtime",
  "rayon",
  "thiserror",
- "windows 0.48.0",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -1644,8 +1643,7 @@ dependencies = [
  "rayon",
  "thiserror",
  "widestring",
- "windows 0.48.0",
- "windows 0.52.0",
+ "windows",
 ]
 
 [[package]]
@@ -3398,15 +3396,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ members = [
     "librashader-build-script"]
 resolver = "2"
 
+[workspace.dependencies]
+windows = "0.52.0"
+
 [workspace.metadata.release]
 
 [profile.optimized]

--- a/librashader-cache/Cargo.toml
+++ b/librashader-cache/Cargo.toml
@@ -23,7 +23,7 @@ persy = "1.4.7"
 bytemuck = "1.13.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Graphics_Direct3D",
     "Win32_Graphics_Direct3D_Fxc",

--- a/librashader-capi/Cargo.toml
+++ b/librashader-capi/Cargo.toml
@@ -45,7 +45,7 @@ default-features = false
 features = ["reflect", "presets", "preprocess"]
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+workspace = true
 optional = true
 
 [target.'cfg(target_vendor="apple")'.dependencies]

--- a/librashader-common/Cargo.toml
+++ b/librashader-common/Cargo.toml
@@ -31,7 +31,7 @@ halfbrown = "0.2.4"
 
 [target.'cfg(windows)'.dependencies.windows]
 optional = true
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",

--- a/librashader-runtime-d3d11/Cargo.toml
+++ b/librashader-runtime-d3d11/Cargo.toml
@@ -25,7 +25,7 @@ rayon = "1.6.1"
 array-concat = "0.5.2"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",

--- a/librashader-runtime-d3d11/Cargo.toml
+++ b/librashader-runtime-d3d11/Cargo.toml
@@ -37,7 +37,7 @@ features = [
 ]
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",
@@ -49,6 +49,7 @@ features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI",
 ]
 
 [[test]]

--- a/librashader-runtime-d3d11/src/draw_quad.rs
+++ b/librashader-runtime-d3d11/src/draw_quad.rs
@@ -65,7 +65,7 @@ impl DrawQuad {
                 &D3D11_BUFFER_DESC {
                     ByteWidth: 2 * std::mem::size_of::<[VertexInput; 4]>() as u32,
                     Usage: D3D11_USAGE_IMMUTABLE,
-                    BindFlags: D3D11_BIND_VERTEX_BUFFER,
+                    BindFlags: D3D11_BIND_VERTEX_BUFFER.0 as u32,
                     CPUAccessFlags: Default::default(),
                     MiscFlags: Default::default(),
                     StructureByteStride: 0,

--- a/librashader-runtime-d3d11/src/filter_chain.rs
+++ b/librashader-runtime-d3d11/src/filter_chain.rs
@@ -36,9 +36,8 @@ use librashader_runtime::uniforms::UniformStorage;
 use rayon::prelude::*;
 use windows::Win32::Graphics::Direct3D11::{
     ID3D11Buffer, ID3D11Device, ID3D11DeviceContext, D3D11_BIND_CONSTANT_BUFFER, D3D11_BUFFER_DESC,
-    D3D11_CPU_ACCESS_WRITE, D3D11_CREATE_DEVICE_SINGLETHREADED, D3D11_RESOURCE_MISC_FLAG,
-    D3D11_RESOURCE_MISC_GENERATE_MIPS, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
-    D3D11_USAGE_DYNAMIC,
+    D3D11_CPU_ACCESS_WRITE, D3D11_CREATE_DEVICE_SINGLETHREADED, D3D11_RESOURCE_MISC_GENERATE_MIPS,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_DYNAMIC,
 };
 use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R8G8B8A8_UNORM;
 
@@ -216,9 +215,9 @@ impl FilterChainD3D11 {
                 &D3D11_BUFFER_DESC {
                     ByteWidth: size,
                     Usage: D3D11_USAGE_DYNAMIC,
-                    BindFlags: D3D11_BIND_CONSTANT_BUFFER,
-                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE,
-                    MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
+                    BindFlags: D3D11_BIND_CONSTANT_BUFFER.0 as u32,
+                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
+                    MiscFlags: 0,
                     StructureByteStride: 0,
                 },
                 None,
@@ -369,9 +368,9 @@ impl FilterChainD3D11 {
                 Format: DXGI_FORMAT_R8G8B8A8_UNORM,
                 Usage: D3D11_USAGE_DEFAULT,
                 MiscFlags: if texture.mipmap {
-                    D3D11_RESOURCE_MISC_GENERATE_MIPS
+                    D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32
                 } else {
-                    D3D11_RESOURCE_MISC_FLAG(0)
+                    0
                 },
                 ..Default::default()
             };

--- a/librashader-runtime-d3d11/src/framebuffer.rs
+++ b/librashader-runtime-d3d11/src/framebuffer.rs
@@ -10,7 +10,7 @@ use windows::Win32::Graphics::Direct3D::D3D_SRV_DIMENSION_TEXTURE2D;
 use windows::Win32::Graphics::Direct3D11::{
     ID3D11Device, ID3D11DeviceContext, ID3D11RenderTargetView, ID3D11ShaderResourceView,
     ID3D11Texture2D, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BOX,
-    D3D11_CPU_ACCESS_FLAG, D3D11_FORMAT_SUPPORT_RENDER_TARGET, D3D11_FORMAT_SUPPORT_SHADER_SAMPLE,
+    D3D11_FORMAT_SUPPORT_RENDER_TARGET, D3D11_FORMAT_SUPPORT_SHADER_SAMPLE,
     D3D11_FORMAT_SUPPORT_TEXTURE2D, D3D11_RENDER_TARGET_VIEW_DESC, D3D11_RENDER_TARGET_VIEW_DESC_0,
     D3D11_RESOURCE_MISC_GENERATE_MIPS, D3D11_RTV_DIMENSION_TEXTURE2D,
     D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_TEX2D_RTV,
@@ -100,7 +100,7 @@ impl OwnedImage {
     pub fn clear(&mut self, ctx: &ID3D11DeviceContext) -> error::Result<()> {
         let rtv = self.create_render_target_view()?;
         unsafe {
-            ctx.ClearRenderTargetView(&rtv, CLEAR.as_ptr());
+            ctx.ClearRenderTargetView(&rtv, CLEAR);
         }
         Ok(())
     }
@@ -240,9 +240,9 @@ fn default_desc(size: Size<u32>, format: DXGI_FORMAT, mip_levels: u32) -> D3D11_
             Quality: 0,
         },
         Usage: D3D11_USAGE_DEFAULT,
-        BindFlags: D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
-        CPUAccessFlags: D3D11_CPU_ACCESS_FLAG(0),
-        MiscFlags: D3D11_RESOURCE_MISC_GENERATE_MIPS,
+        BindFlags: (D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET).0 as u32,
+        CPUAccessFlags: 0,
+        MiscFlags: D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32,
     }
 }
 

--- a/librashader-runtime-d3d11/src/graphics_pipeline.rs
+++ b/librashader-runtime-d3d11/src/graphics_pipeline.rs
@@ -84,7 +84,7 @@ impl D3D11State {
             let mut saved_blend_mask = 0;
             context.OMGetBlendState(
                 Some(&mut saved_blend),
-                Some(saved_blend_factor.as_mut_ptr()),
+                Some(&mut saved_blend_factor),
                 Some(&mut saved_blend_mask),
             );
             let saved_rs = context.RSGetState().ok();
@@ -113,7 +113,7 @@ impl Drop for D3D11StateSaveGuard<'_> {
             self.ctx.RSSetState(self.saved_rs.as_ref());
             self.ctx.OMSetBlendState(
                 self.saved_blend.as_ref(),
-                Some(self.saved_blend_factor.as_ptr()),
+                Some(&self.saved_blend_factor),
                 self.saved_blend_mask,
             );
         }

--- a/librashader-runtime-d3d11/src/texture.rs
+++ b/librashader-runtime-d3d11/src/texture.rs
@@ -4,9 +4,8 @@ use librashader_runtime::scaling::MipmapSize;
 use windows::Win32::Graphics::Direct3D::D3D_SRV_DIMENSION_TEXTURE2D;
 use windows::Win32::Graphics::Direct3D11::{
     ID3D11Device, ID3D11DeviceContext, ID3D11RenderTargetView, ID3D11ShaderResourceView,
-    ID3D11Texture2D, D3D11_BIND_FLAG, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE,
-    D3D11_BOX, D3D11_CPU_ACCESS_FLAG, D3D11_CPU_ACCESS_WRITE, D3D11_RESOURCE_MISC_FLAG,
-    D3D11_RESOURCE_MISC_GENERATE_MIPS, D3D11_SHADER_RESOURCE_VIEW_DESC,
+    ID3D11Texture2D, D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BOX,
+    D3D11_CPU_ACCESS_WRITE, D3D11_RESOURCE_MISC_GENERATE_MIPS, D3D11_SHADER_RESOURCE_VIEW_DESC,
     D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_SRV,
     D3D11_TEXTURE2D_DESC, D3D11_USAGE_DYNAMIC, D3D11_USAGE_STAGING,
 };
@@ -96,7 +95,7 @@ impl LutTexture {
             Width: source.size.width,
             Height: source.size.height,
             // todo: set this to 0
-            MipLevels: if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
+            MipLevels: if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
                 0
             } else {
                 1
@@ -107,17 +106,17 @@ impl LutTexture {
                 Quality: 0,
             },
             CPUAccessFlags: if desc.Usage == D3D11_USAGE_DYNAMIC {
-                D3D11_CPU_ACCESS_WRITE
+                D3D11_CPU_ACCESS_WRITE.0 as u32
             } else {
-                D3D11_CPU_ACCESS_FLAG(0)
+                0
             },
             ..desc
         };
-        desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+        desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE.0 as u32;
 
         // determine number of mipmaps required
-        if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
-            desc.BindFlags |= D3D11_BIND_RENDER_TARGET;
+        if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
+            desc.BindFlags |= D3D11_BIND_RENDER_TARGET.0 as u32;
             desc.MipLevels = source.size.calculate_miplevels();
         }
 
@@ -134,10 +133,10 @@ impl LutTexture {
             device.CreateTexture2D(
                 &D3D11_TEXTURE2D_DESC {
                     MipLevels: 1,
-                    BindFlags: D3D11_BIND_FLAG(0),
-                    MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
+                    BindFlags: 0,
+                    MiscFlags: 0,
                     Usage: D3D11_USAGE_STAGING,
-                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE,
+                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                     ..desc
                 },
                 Some(&D3D11_SUBRESOURCE_DATA {
@@ -184,7 +183,7 @@ impl LutTexture {
             )?;
             assume_d3d11_init!(srv, "CreateShaderResourceView");
 
-            if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
+            if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
                 context.GenerateMips(&srv)
             }
 

--- a/librashader-runtime-d3d11/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d11/tests/hello_triangle/mod.rs
@@ -104,7 +104,7 @@ where
         cbSize: std::mem::size_of::<WNDCLASSEXA>() as u32,
         style: CS_HREDRAW | CS_VREDRAW,
         lpfnWndProc: Some(wndproc::<S>),
-        hInstance: instance,
+        hInstance: HINSTANCE::from(instance),
         hCursor: unsafe { LoadCursorW(None, IDC_ARROW)? },
         lpszClassName: s!("RustWindowClass"),
         ..Default::default()
@@ -121,7 +121,7 @@ where
         right: size.0,
         bottom: size.1,
     };
-    unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false) };
+    unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false)? };
 
     let mut title = sample.title();
 
@@ -310,7 +310,7 @@ pub mod d3d11_hello_triangle {
                             Quality: 0,
                         },
                         Usage: D3D11_USAGE_DYNAMIC,
-                        BindFlags: D3D11_BIND_SHADER_RESOURCE,
+                        BindFlags: D3D11_BIND_SHADER_RESOURCE.0 as u32,
                         CPUAccessFlags: Default::default(),
                         MiscFlags: Default::default(),
                     },
@@ -382,7 +382,7 @@ pub mod d3d11_hello_triangle {
                 let mut desc = Default::default();
 
                 backbuffer.GetDesc(&mut desc);
-                desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+                desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE.0 as u32;
 
                 self.device
                     .CreateTexture2D(&desc, None, Some(&mut renderbuffer))?;
@@ -501,7 +501,7 @@ pub mod d3d11_hello_triangle {
             unsafe {
                 let color = [0.3, 0.4, 0.6, 1.0];
                 self.context
-                    .ClearRenderTargetView(&resources.renderbufffer_rtv, color.as_ptr());
+                    .ClearRenderTargetView(&resources.renderbufffer_rtv, &color);
                 self.context.ClearDepthStencilView(
                     &resources.depth_stencil_view,
                     D3D11_CLEAR_DEPTH.0,
@@ -727,7 +727,7 @@ pub mod d3d11_hello_triangle {
                         Quality: 0,
                     },
                     Usage: D3D11_USAGE_DEFAULT,
-                    BindFlags: D3D11_BIND_DEPTH_STENCIL,
+                    BindFlags: D3D11_BIND_DEPTH_STENCIL.0 as u32,
                     CPUAccessFlags: Default::default(),
                     MiscFlags: Default::default(),
                 },
@@ -764,8 +764,8 @@ pub mod d3d11_hello_triangle {
                 &D3D11_BUFFER_DESC {
                     ByteWidth: (std::mem::size_of::<TriangleUniforms>()) as u32,
                     Usage: D3D11_USAGE_DYNAMIC,
-                    BindFlags: D3D11_BIND_CONSTANT_BUFFER,
-                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE,
+                    BindFlags: D3D11_BIND_CONSTANT_BUFFER.0 as u32,
+                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                     MiscFlags: Default::default(),
                     StructureByteStride: 0,
                 },
@@ -799,7 +799,7 @@ pub mod d3d11_hello_triangle {
                 &D3D11_BUFFER_DESC {
                     ByteWidth: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
                     Usage: D3D11_USAGE_DEFAULT,
-                    BindFlags: D3D11_BIND_VERTEX_BUFFER,
+                    BindFlags: D3D11_BIND_VERTEX_BUFFER.0 as u32,
                     CPUAccessFlags: Default::default(),
                     MiscFlags: Default::default(),
                     StructureByteStride: 0,
@@ -817,7 +817,7 @@ pub mod d3d11_hello_triangle {
                 &D3D11_BUFFER_DESC {
                     ByteWidth: (std::mem::size_of::<u32>() * indices.len()) as u32,
                     Usage: D3D11_USAGE_DEFAULT,
-                    BindFlags: D3D11_BIND_INDEX_BUFFER,
+                    BindFlags: D3D11_BIND_INDEX_BUFFER.0 as u32,
                     CPUAccessFlags: Default::default(),
                     MiscFlags: Default::default(),
                     StructureByteStride: 0,

--- a/librashader-runtime-d3d11/tests/hello_triangle/texture.rs
+++ b/librashader-runtime-d3d11/tests/hello_triangle/texture.rs
@@ -3,11 +3,11 @@ use librashader_runtime::image::Image;
 use librashader_runtime::scaling::MipmapSize;
 use windows::Win32::Graphics::Direct3D::D3D_SRV_DIMENSION_TEXTURE2D;
 use windows::Win32::Graphics::Direct3D11::{
-    ID3D11Device, ID3D11DeviceContext, ID3D11ShaderResourceView, ID3D11Texture2D, D3D11_BIND_FLAG,
-    D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BOX, D3D11_CPU_ACCESS_FLAG,
-    D3D11_CPU_ACCESS_WRITE, D3D11_RESOURCE_MISC_FLAG, D3D11_RESOURCE_MISC_GENERATE_MIPS,
-    D3D11_SHADER_RESOURCE_VIEW_DESC, D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA,
-    D3D11_TEX2D_SRV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DYNAMIC, D3D11_USAGE_STAGING,
+    ID3D11Device, ID3D11DeviceContext, ID3D11ShaderResourceView, ID3D11Texture2D,
+    D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BOX, D3D11_CPU_ACCESS_WRITE,
+    D3D11_RESOURCE_MISC_GENERATE_MIPS, D3D11_SHADER_RESOURCE_VIEW_DESC,
+    D3D11_SHADER_RESOURCE_VIEW_DESC_0, D3D11_SUBRESOURCE_DATA, D3D11_TEX2D_SRV,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE_DYNAMIC, D3D11_USAGE_STAGING,
 };
 use windows::Win32::Graphics::Dxgi::Common::DXGI_SAMPLE_DESC;
 
@@ -64,7 +64,7 @@ impl ExampleTexture {
             Width: source.size.width,
             Height: source.size.height,
             // todo: set this to 0
-            MipLevels: if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
+            MipLevels: if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
                 0
             } else {
                 1
@@ -75,17 +75,17 @@ impl ExampleTexture {
                 Quality: 0,
             },
             CPUAccessFlags: if desc.Usage == D3D11_USAGE_DYNAMIC {
-                D3D11_CPU_ACCESS_WRITE
+                D3D11_CPU_ACCESS_WRITE.0 as u32
             } else {
-                D3D11_CPU_ACCESS_FLAG(0)
+                0
             },
             ..desc
         };
-        desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+        desc.BindFlags |= D3D11_BIND_SHADER_RESOURCE.0 as u32;
 
         // determine number of mipmaps required
-        if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
-            desc.BindFlags |= D3D11_BIND_RENDER_TARGET;
+        if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
+            desc.BindFlags |= D3D11_BIND_RENDER_TARGET.0 as u32;
             desc.MipLevels = source.size.calculate_miplevels();
         }
 
@@ -102,10 +102,10 @@ impl ExampleTexture {
             device.CreateTexture2D(
                 &D3D11_TEXTURE2D_DESC {
                     MipLevels: 1,
-                    BindFlags: D3D11_BIND_FLAG(0),
-                    MiscFlags: D3D11_RESOURCE_MISC_FLAG(0),
+                    BindFlags: 0,
+                    MiscFlags: 0,
                     Usage: D3D11_USAGE_STAGING,
-                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE,
+                    CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
                     ..desc
                 },
                 Some(&D3D11_SUBRESOURCE_DATA {
@@ -152,7 +152,7 @@ impl ExampleTexture {
             )?;
             let srv = srv.unwrap();
 
-            if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS).0 != 0 {
+            if (desc.MiscFlags & D3D11_RESOURCE_MISC_GENERATE_MIPS.0 as u32) != 0 {
                 context.GenerateMips(&srv)
             }
 

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -32,7 +32,7 @@ mach-siegbert-vogt-dxcsa = "0.1.3"
 rayon = "1.6.1"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -44,7 +44,7 @@ features = [
 ]
 
 [target.'cfg(windows)'.dev-dependencies.windows]
-version = "0.48.0"
+workspace = true
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Dxgi_Common",

--- a/librashader-runtime-d3d12/src/filter_chain.rs
+++ b/librashader-runtime-d3d12/src/filter_chain.rs
@@ -234,7 +234,7 @@ impl FilterChainD3D12 {
             if fence.GetCompletedValue() < 1 {
                 fence.SetEventOnCompletion(1, fence_event)?;
                 WaitForSingleObject(fence_event, INFINITE);
-                CloseHandle(fence_event);
+                CloseHandle(fence_event)?;
             }
 
             Ok(filter_chain)

--- a/librashader-runtime-d3d12/src/framebuffer.rs
+++ b/librashader-runtime-d3d12/src/framebuffer.rs
@@ -231,7 +231,7 @@ impl OwnedImage {
 
         let rtv = self.create_render_target_view(heap)?;
 
-        unsafe { cmd.ClearRenderTargetView(*rtv.descriptor.as_ref(), CLEAR.as_ptr(), None) }
+        unsafe { cmd.ClearRenderTargetView(*rtv.descriptor.as_ref(), CLEAR, None) }
 
         util::d3d12_resource_transition(
             cmd,

--- a/librashader-runtime-d3d12/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d12/tests/hello_triangle/mod.rs
@@ -69,7 +69,7 @@ where
         cbSize: std::mem::size_of::<WNDCLASSEXA>() as u32,
         style: CS_HREDRAW | CS_VREDRAW,
         lpfnWndProc: Some(wndproc::<S>),
-        hInstance: instance,
+        hInstance: HINSTANCE::from(instance),
         hCursor: unsafe { LoadCursorW(None, IDC_ARROW)? },
         lpszClassName: s!("RustWindowClass"),
         ..Default::default()
@@ -86,7 +86,7 @@ where
         right: size.0,
         bottom: size.1,
     };
-    unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false) };
+    unsafe { AdjustWindowRect(&mut window_rect, WS_OVERLAPPEDWINDOW, false)? };
 
     let mut title = sample.title();
 
@@ -190,7 +190,7 @@ fn get_hardware_adapter(factory: &IDXGIFactory4) -> Result<IDXGIAdapter1> {
         let mut desc = Default::default();
         unsafe { adapter.GetDesc1(&mut desc)? };
 
-        if (DXGI_ADAPTER_FLAG(desc.Flags) & DXGI_ADAPTER_FLAG_SOFTWARE) != DXGI_ADAPTER_FLAG_NONE {
+        if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE.0 as u32) != DXGI_ADAPTER_FLAG_NONE.0 as u32 {
             // Don't select the Basic Render Driver adapter. If you want a
             // software adapter, pass in "/warp" on the command line.
             continue;
@@ -583,12 +583,7 @@ pub mod d3d12_hello_triangle {
 
         // Record commands.
         unsafe {
-            // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1006
-            command_list.ClearRenderTargetView(
-                rtv_handle,
-                &*[0.3, 0.4, 0.6, 1.0].as_ptr(),
-                Some(&[]),
-            );
+            command_list.ClearRenderTargetView(rtv_handle, &[0.3, 0.4, 0.6, 1.0], Some(&[]));
             command_list.IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             command_list.IASetVertexBuffers(0, Some(&[resources.vbv]));
             command_list.DrawInstanced(3, 1, 0, 0);

--- a/librashader-runtime/Cargo.toml
+++ b/librashader-runtime/Cargo.toml
@@ -16,7 +16,7 @@ librashader-common = { path = "../librashader-common", version = "0.2.3" }
 librashader-presets = { path = "../librashader-presets", version = "0.2.3" }
 librashader-preprocess = { path = "../librashader-preprocess", version = "0.2.3" }
 librashader-reflect = { path = "../librashader-reflect", version = "0.2.3" }
-bytemuck = "1.12.3"
+bytemuck = {  version = "1.12.3", features = ["derive"] }
 num-traits = "0.2.15"
 array-concat = "0.5.2"
 

--- a/librashader/Cargo.toml
+++ b/librashader/Cargo.toml
@@ -34,7 +34,7 @@ librashader-runtime-wgpu = { path = "../librashader-runtime-wgpu", version = "0.
 wgpu-types = { version = "0.19", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.48.0"
+workspace = true
 optional = true
 
 [target.'cfg(target_vendor="apple")'.dependencies]


### PR DESCRIPTION
No real huge differences here. 0.52.0 seems to be pretty widely used at the moment, whereas 0.53.0 is too fresh. 