### PR TITLE
spirv-to-dxbc pipeline for D3D11

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ and are more a heads-up for integrating librashader into your project.
 ## Versioning
 [![Latest Version](https://img.shields.io/crates/v/librashader.svg)](https://crates.io/crates/librashader)
 ![C ABI](https://img.shields.io/badge/ABI%20version-1-yellowgreen)
-![C API](https://img.shields.io/badge/API%20version-1-blue)
+![C API](https://img.shields.io/badge/API%20version-2-blue)
 
 
 librashader typically follows [Semantic Versioning](https://semver.org/) with respect to the Rust API, where a minor version
@@ -195,8 +195,8 @@ number bump indicates a 'breaking change' during `0.x.y`, and a non-'breaking ch
 The C API is instead versioned separately with two monotonically increasing version numbers exported to the librashader
 C headers
 
-- [`LIBRASHADER_CURRENT_VERSION`](https://github.com/SnowflakePowered/librashader/blob/f8de1fa2ee75270e5655284edf39ea070d6ec6f5/librashader-capi/src/version.rs#L16) specifies the *API* version exported by the librashader implementation.
-- [`LIBRASHADER_CURRENT_ABI`](https://github.com/SnowflakePowered/librashader/blob/f8de1fa2ee75270e5655284edf39ea070d6ec6f5/librashader-capi/src/version.rs#L29) specifies the *ABI* version exported by the librashader implementation.
+- [`LIBRASHADER_CURRENT_VERSION`](https://github.com/SnowflakePowered/librashader/blob/8a9adebb96c50816e2a38565e3a0b968b84370dc/librashader-capi/src/version.rs#L20) specifies the *API* version exported by the librashader implementation.
+- [`LIBRASHADER_CURRENT_ABI`](https://github.com/SnowflakePowered/librashader/blob/8a9adebb96c50816e2a38565e3a0b968b84370dc/librashader-capi/src/version.rs#L33 specifies the *ABI* version exported by the librashader implementation.
 
 An increase in `LIBRASHADER_CURRENT_VERSION` is guaranteed to be **backwards compatible for the same `LIBRASHADER_CURRENT_ABI`**.
 It somewhat corresponds to a "minor" version in semantic versioning terminology, except that it is always monotonically increasing.

--- a/librashader-capi/src/runtime/d3d11/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d11/filter_chain.rs
@@ -40,11 +40,20 @@ pub struct filter_chain_d3d11_opt_t {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+
+    /// Force the HLSL shader pipeline. This will force the usage of the slower,
+    /// Fxc shader compiler.
+    pub force_hlsl_pipeline: bool,
+
+    /// Force the SPIR-V to DXBC pipeline, disabling the HLSL pipeline.
+    /// If this is true, overrides `force_hlsl_pipeline`.
+    pub force_spirv_pipeline: bool,
 }
 
 config_struct! {
     impl FilterChainOptions => filter_chain_d3d11_opt_t {
         0 => [force_no_mipmaps, disable_cache];
+        2 => [force_hlsl_pipeline, force_spirv_pipeline];
     }
 }
 

--- a/librashader-capi/src/runtime/d3d12/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d12/filter_chain.rs
@@ -87,11 +87,16 @@ pub struct filter_chain_d3d12_opt_t {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+
+    /// Force the SPIR-V to DXIL pipeline, disabling the HLSL pipeline.
+    /// If this is true, overrides `force_hlsl_pipeline`.
+    pub force_spirv_pipeline: bool,
 }
 
 config_struct! {
     impl FilterChainOptions => filter_chain_d3d12_opt_t {
-        0 =>  [force_hlsl_pipeline, force_no_mipmaps, disable_cache];
+        0 => [force_hlsl_pipeline, force_no_mipmaps, disable_cache];
+        2 => [force_spirv_pipeline];
     }
 }
 

--- a/librashader-capi/src/version.rs
+++ b/librashader-capi/src/version.rs
@@ -17,7 +17,10 @@ pub type LIBRASHADER_ABI_VERSION = usize;
 ///     - Added rotation, total_subframes, current_subframes to frame options
 ///     - Added preset context API
 ///     - Added Metal runtime API
-pub const LIBRASHADER_CURRENT_VERSION: LIBRASHADER_API_VERSION = 1;
+/// - API version 2: 0.3.0
+///     - Added spirv-to-dxbc options for Direct3D 11
+///     - Added force spirv-to-dxil options for Direct3D 12
+pub const LIBRASHADER_CURRENT_VERSION: LIBRASHADER_API_VERSION = 2;
 
 /// The current version of the librashader ABI.
 /// Used by the loader to check ABI compatibility.

--- a/librashader-runtime-d3d11/src/options.rs
+++ b/librashader-runtime-d3d11/src/options.rs
@@ -13,4 +13,10 @@ pub struct FilterChainOptionsD3D11 {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+    /// Force the HLSL shader pipeline. This will force the usage of the slower,
+    /// Fxc shader compiler.
+    pub force_hlsl_pipeline: bool,
+    /// Force the SPIR-V to DXBC pipeline, disabling the HLSL pipeline.
+    /// If this is true, overrides `force_hlsl_pipeline`.
+    pub force_spirv_pipeline: bool,
 }

--- a/librashader-runtime-d3d12/src/options.rs
+++ b/librashader-runtime-d3d12/src/options.rs
@@ -18,4 +18,8 @@ pub struct FilterChainOptionsD3D12 {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+
+    /// Force the SPIR-V to DXIL pipeline, disabling the HLSL pipeline.
+    /// If this is true, overrides `force_hlsl_pipeline`.
+    pub force_spirv_pipeline: bool,
 }


### PR DESCRIPTION
Fixes #61 

This implements a spirv-to-dxbc pipeline for D3D11, possibly bypassing HLSL -> Fxc completely for compilation of shaders on par with Vulkan speeds