### PR TITLE
gl: load luts with TopLeft orientation, flipping render buffer instead

### DIFF
--- a/librashader-runtime-gl/src/filter_chain/filter_impl.rs
+++ b/librashader-runtime-gl/src/filter_chain/filter_impl.rs
@@ -10,7 +10,7 @@ use crate::texture::InputTexture;
 use crate::util::{gl_get_version, gl_u16_to_version};
 use crate::{error, GLImage};
 use gl::types::GLuint;
-use librashader_common::Viewport;
+use librashader_common::{FilterMode, Viewport, WrapMode};
 
 use librashader_presets::{ShaderPassConfig, ShaderPreset, TextureConfig};
 use librashader_reflect::back::glsl::GlslVersion;
@@ -250,7 +250,7 @@ impl<T: GLInterface> FilterChainImpl<T> {
                 T::FramebufferInterface::init(&mut back, input.size, input.format)?;
             }
 
-            back.copy_from::<T::FramebufferInterface>(input)?;
+            back.copy_from::<T::FramebufferInterface>(input, false)?;
             self.history_framebuffers.push_front(back)
         }
 
@@ -302,12 +302,17 @@ impl<T: GLInterface> FilterChainImpl<T> {
         }
 
         // shader_gl3: 2067
-        let original = InputTexture {
-            image: *input,
-            filter,
-            mip_filter: filter,
-            wrap_mode,
-        };
+        // let original = InputTexture {
+        //     image: *input,
+        //     filter,
+        //     mip_filter: filter,
+        //     wrap_mode,
+        // };
+
+        let mut flipped = T::FramebufferInterface::new(1);
+        flipped.copy_from::<T::FramebufferInterface>(&input, true)?;
+
+        let original = flipped.as_texture(filter, wrap_mode);
 
         let mut source = original;
 
@@ -363,9 +368,19 @@ impl<T: GLInterface> FilterChainImpl<T> {
         }
 
         self.draw_quad.bind_vertices(QuadType::Final);
+
         // try to hint the optimizer
         assert_eq!(last.len(), 1);
         if let Some(pass) = last.iter_mut().next() {
+            // Need to flip the output, so we'll render to a backbuffer before blitting back to the viewport.
+            let mut output = T::FramebufferInterface::new(1);
+            output.right_size::<T::FramebufferInterface>(
+                &viewport
+                    .output
+                    .as_texture(FilterMode::Linear, WrapMode::ClampToEdge)
+                    .image,
+            )?;
+
             source.filter = pass.config.filter;
             source.mip_filter = pass.config.filter;
             source.wrap_mode = pass.config.wrap_mode;
@@ -378,11 +393,22 @@ impl<T: GLInterface> FilterChainImpl<T> {
                 viewport,
                 &original,
                 &source,
-                RenderTarget::viewport(viewport),
+                RenderTarget::viewport_with_output(&output, viewport),
             );
-            self.common.output_textures[passes_len - 1] = viewport
-                .output
-                .as_texture(pass.config.filter, pass.config.wrap_mode);
+            self.common.output_textures[passes_len - 1] =
+                output.as_texture(pass.config.filter, pass.config.wrap_mode);
+
+            // SAFETY: viewport should be the same size as output texture.
+            unsafe {
+                viewport
+                    .output
+                    .copy_from_unchecked::<T::FramebufferInterface>(
+                        &output
+                            .as_texture(pass.config.filter, pass.config.wrap_mode)
+                            .image,
+                        true,
+                    )?;
+            }
         }
 
         // swap feedback framebuffers with output
@@ -392,7 +418,6 @@ impl<T: GLInterface> FilterChainImpl<T> {
         );
 
         self.push_history(input)?;
-
         self.draw_quad.unbind_vertices();
 
         Ok(())

--- a/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
@@ -80,12 +80,8 @@ impl FramebufferInterface for Gl3Framebuffer {
             }
         }
     }
-    fn copy_from(fb: &mut GLFramebuffer, image: &GLImage) -> Result<()> {
-        // todo: may want to use a shader and draw a quad to be faster.
-        if image.size != fb.size || image.format != fb.format {
-            Self::init(fb, image.size, image.format)?;
-        }
 
+    unsafe fn copy_from_unchecked(fb: &GLFramebuffer, image: &GLImage, flip_y: bool) -> Result<()> {
         unsafe {
             gl::BindFramebuffer(gl::FRAMEBUFFER, fb.fbo);
 
@@ -112,9 +108,9 @@ impl FramebufferInterface for Gl3Framebuffer {
                 fb.size.width as GLint,
                 fb.size.height as GLint,
                 0,
-                0,
+                if flip_y { fb.size.height as GLint } else { 0 },
                 fb.size.width as GLint,
-                fb.size.height as GLint,
+                if flip_y { 0 } else { fb.size.height as GLint },
                 gl::COLOR_BUFFER_BIT,
                 gl::NEAREST,
             );

--- a/librashader-runtime-gl/src/gl/gl3/lut_load.rs
+++ b/librashader-runtime-gl/src/gl/gl3/lut_load.rs
@@ -21,7 +21,7 @@ impl LoadLut for Gl3LutLoad {
 
         let images = textures
             .par_iter()
-            .map(|texture| Image::load(&texture.path, UVDirection::BottomLeft))
+            .map(|texture| Image::load(&texture.path, UVDirection::TopLeft))
             .collect::<std::result::Result<Vec<Image>, ImageError>>()?;
 
         for (index, (texture, image)) in textures.iter().zip(images).enumerate() {

--- a/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
@@ -77,15 +77,10 @@ impl FramebufferInterface for Gl46Framebuffer {
             );
         }
     }
-    fn copy_from(fb: &mut GLFramebuffer, image: &GLImage) -> Result<()> {
+    unsafe fn copy_from_unchecked(fb: &GLFramebuffer, image: &GLImage, flip_y: bool) -> Result<()> {
         // todo: confirm this behaviour for unbound image.
         if image.handle == 0 {
             return Ok(());
-        }
-
-        // todo: may want to use a shader and draw a quad to be faster.
-        if image.size != fb.size || image.format != fb.format {
-            Self::init(fb, image.size, image.format)?;
         }
 
         unsafe {
@@ -101,9 +96,9 @@ impl FramebufferInterface for Gl46Framebuffer {
                 image.size.width as GLint,
                 image.size.height as GLint,
                 0,
-                0,
+                if flip_y { fb.size.height as GLint } else { 0 },
                 fb.size.width as GLint,
-                fb.size.height as GLint,
+                if flip_y { 0 } else { fb.size.height as GLint },
                 gl::COLOR_BUFFER_BIT,
                 gl::NEAREST,
             );

--- a/librashader-runtime-gl/src/gl/gl46/lut_load.rs
+++ b/librashader-runtime-gl/src/gl/gl46/lut_load.rs
@@ -25,7 +25,7 @@ impl LoadLut for Gl46LutLoad {
 
         let images = textures
             .par_iter()
-            .map(|texture| Image::load(&texture.path, UVDirection::BottomLeft))
+            .map(|texture| Image::load(&texture.path, UVDirection::TopLeft))
             .collect::<std::result::Result<Vec<Image>, ImageError>>()?;
 
         for (index, (texture, image)) in textures.iter().zip(images).enumerate() {

--- a/librashader-runtime-gl/src/gl/mod.rs
+++ b/librashader-runtime-gl/src/gl/mod.rs
@@ -95,7 +95,7 @@ pub(crate) trait FramebufferInterface {
         mipmap: bool,
     ) -> Result<Size<u32>>;
     fn clear<const REBIND: bool>(fb: &GLFramebuffer);
-    fn copy_from(fb: &mut GLFramebuffer, image: &GLImage) -> Result<()>;
+    unsafe fn copy_from_unchecked(fb: &GLFramebuffer, image: &GLImage, flip_y: bool) -> Result<()>;
     fn init(fb: &mut GLFramebuffer, size: Size<u32>, format: impl Into<GLenum>) -> Result<()>;
 }
 

--- a/librashader-runtime-gl/tests/triangle.rs
+++ b/librashader-runtime-gl/tests/triangle.rs
@@ -9,7 +9,8 @@ fn triangle_gl() {
 
     unsafe {
         let mut filter = FilterChainGL::load_from_path(
-            "../test/shaders_slang/crt/crt-royale.slangp",
+            "../test/shaders_slang/crt/crt-hyllian.slangp",
+            // "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             Some(&FilterChainOptionsGL {
                 glsl_version: 0,
                 use_dsa: false,
@@ -30,7 +31,7 @@ fn triangle_gl46() {
         let mut filter = FilterChainGL::load_from_path(
             // "../test/slang-shaders/vhs/VHSPro.slangp",
             // "../test/slang-shaders/test/history.slangp",
-            "../test/shaders_slang/crt/crt-royale.slangp",
+            "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             // "../test/shadersslang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
             Some(&FilterChainOptionsGL {
                 glsl_version: 0,


### PR DESCRIPTION
Fixes issues with LUT sampling on crt-hyllian.

See https://github.com/libretro/slang-shaders/issues/552