### PR TITLE
Rely on `GetDesc` rather than manual size data

### DIFF
--- a/librashader-capi/src/runtime/d3d12/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d12/filter_chain.rs
@@ -26,11 +26,11 @@ pub struct libra_source_image_d3d12_t {
     pub resource: ManuallyDrop<ID3D12Resource>,
     /// A CPU descriptor handle to a shader resource view of the image.
     pub descriptor: D3D12_CPU_DESCRIPTOR_HANDLE,
-    /// The format of the image.
+    /// This is currently ignored.
     pub format: DXGI_FORMAT,
-    /// The width of the source image.
+    /// This is currently ignored.
     pub width: u32,
-    /// The height of the source image.
+    /// This is currently ignored.
     pub height: u32,
 }
 
@@ -104,8 +104,6 @@ impl TryFrom<libra_source_image_d3d12_t> for D3D12InputImage {
         Ok(D3D12InputImage {
             resource: ManuallyDrop::into_inner(resource),
             descriptor: value.descriptor,
-            size: Size::new(value.width, value.height),
-            format: value.format,
         })
     }
 }

--- a/librashader-runtime-d3d11/src/framebuffer.rs
+++ b/librashader-runtime-d3d11/src/framebuffer.rs
@@ -1,7 +1,6 @@
+use crate::error;
 use crate::error::{assume_d3d11_init, FilterChainError};
-use crate::texture::D3D11InputView;
 use crate::util::d3d11_get_closest_format;
-use crate::{error, D3D11OutputView};
 use librashader_common::{ImageFormat, Size};
 use librashader_presets::Scale2D;
 use librashader_runtime::scaling::{MipmapSize, ScaleFramebuffer, ViewportSize};
@@ -171,33 +170,25 @@ impl OwnedImage {
         Ok(rtv)
     }
 
-    pub fn as_output(&self) -> error::Result<D3D11OutputView> {
-        let rtv = self.create_render_target_view()?;
-        Ok(D3D11OutputView {
-            handle: rtv,
-            size: self.size,
-        })
-    }
-
     pub fn copy_from(
         &mut self,
         ctx: &ID3D11DeviceContext,
-        image: &D3D11InputView,
+        image: &ID3D11ShaderResourceView,
     ) -> error::Result<()> {
         let original_resource: ID3D11Texture2D = unsafe {
-            let resource = image.handle.GetResource()?;
+            let resource = image.GetResource()?;
             resource.cast()?
         };
 
-        let format = unsafe {
+        let (format, image_size) = unsafe {
             let mut desc = Default::default();
             original_resource.GetDesc(&mut desc);
-            desc.Format
+            (desc.Format, Size::new(desc.Width, desc.Height))
         };
 
-        if self.size != image.size || format != self.format {
+        if self.size != image_size || format != self.format {
             // eprintln!("[history] resizing");
-            self.init(image.size, ImageFormat::from(format))?;
+            self.init(image_size, ImageFormat::from(format))?;
         }
 
         unsafe {

--- a/librashader-runtime-d3d11/src/lib.rs
+++ b/librashader-runtime-d3d11/src/lib.rs
@@ -25,5 +25,3 @@ use librashader_runtime::impl_filter_chain_parameters;
 impl_filter_chain_parameters!(FilterChainD3D11);
 
 pub use filter_chain::FilterChainD3D11;
-pub use texture::D3D11InputView;
-pub use texture::D3D11OutputView;

--- a/librashader-runtime-d3d11/src/luts.rs
+++ b/librashader-runtime-d3d11/src/luts.rs
@@ -1,6 +1,6 @@
+use crate::error;
 use crate::error::assume_d3d11_init;
 use crate::texture::InputTexture;
-use crate::{error, D3D11InputView};
 use librashader_common::{FilterMode, WrapMode};
 use librashader_runtime::image::Image;
 use librashader_runtime::scaling::MipmapSize;
@@ -139,10 +139,7 @@ impl LutTexture {
                 handle,
                 desc,
                 image: InputTexture {
-                    view: D3D11InputView {
-                        handle: srv,
-                        size: source.size,
-                    },
+                    view: srv,
                     filter,
                     wrap_mode,
                 },

--- a/librashader-runtime-d3d11/src/texture.rs
+++ b/librashader-runtime-d3d11/src/texture.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::framebuffer::OwnedImage;
-use librashader_common::{FilterMode, Size, WrapMode};
+use librashader_common::{FilterMode, WrapMode};
 use windows::Win32::Graphics::Direct3D11::{ID3D11RenderTargetView, ID3D11ShaderResourceView};
 
 /// An image view for use as a shader resource.
@@ -10,8 +10,6 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11RenderTargetView, ID3D11ShaderR
 pub struct D3D11InputView {
     /// A handle to the shader resource view.
     pub handle: ID3D11ShaderResourceView,
-    /// The size of the image.
-    pub size: Size<u32>,
 }
 
 /// An image view for use as a render target.
@@ -21,13 +19,11 @@ pub struct D3D11InputView {
 pub struct D3D11OutputView {
     /// A handle to the render target view.
     pub handle: ID3D11RenderTargetView,
-    /// The size of the image.
-    pub size: Size<u32>,
 }
 
 #[derive(Debug, Clone)]
 pub struct InputTexture {
-    pub view: D3D11InputView,
+    pub view: ID3D11ShaderResourceView,
     pub filter: FilterMode,
     pub wrap_mode: WrapMode,
 }
@@ -39,10 +35,7 @@ impl InputTexture {
         filter: FilterMode,
     ) -> Result<Self> {
         Ok(InputTexture {
-            view: D3D11InputView {
-                handle: fbo.create_shader_resource_view()?,
-                size: fbo.size,
-            },
+            view: fbo.create_shader_resource_view()?,
             filter,
             wrap_mode,
         })

--- a/librashader-runtime-d3d11/src/util.rs
+++ b/librashader-runtime-d3d11/src/util.rs
@@ -1,7 +1,8 @@
 use crate::error;
 use crate::error::assume_d3d11_init;
+use librashader_common::Size;
 use std::slice;
-use windows::core::PCSTR;
+use windows::core::{ComInterface, PCSTR};
 use windows::Win32::Graphics::Direct3D::Fxc::{
     D3DCompile, D3DCOMPILE_DEBUG, D3DCOMPILE_OPTIMIZATION_LEVEL3, D3DCOMPILE_SKIP_OPTIMIZATION,
 };
@@ -173,5 +174,41 @@ pub fn d3d11_create_input_layout(
         device.CreateInputLayout(desc, dxil, Some(&mut input_layout))?;
         assume_d3d11_init!(input_layout, "CreateInputLayout");
         Ok(input_layout)
+    }
+}
+
+pub(crate) trait GetSize {
+    fn size(&self) -> error::Result<Size<u32>>;
+}
+
+impl GetSize for ID3D11RenderTargetView {
+    fn size(&self) -> error::Result<Size<u32>> {
+        let parent = unsafe { self.GetResource()?.cast::<ID3D11Texture2D>()? };
+
+        let mut desc = Default::default();
+        unsafe {
+            parent.GetDesc(&mut desc);
+        }
+
+        Ok(Size {
+            height: desc.Height,
+            width: desc.Width,
+        })
+    }
+}
+
+impl GetSize for ID3D11ShaderResourceView {
+    fn size(&self) -> error::Result<Size<u32>> {
+        let parent = unsafe { self.GetResource()?.cast::<ID3D11Texture2D>()? };
+
+        let mut desc = Default::default();
+        unsafe {
+            parent.GetDesc(&mut desc);
+        }
+
+        Ok(Size {
+            height: desc.Height,
+            width: desc.Width,
+        })
     }
 }

--- a/librashader-runtime-d3d11/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d11/tests/hello_triangle/mod.rs
@@ -246,7 +246,6 @@ pub mod d3d11_hello_triangle {
     use librashader_runtime::image::Image;
     use librashader_runtime_d3d11::options::FilterChainOptionsD3D11;
     use librashader_runtime_d3d11::FilterChainD3D11;
-    use librashader_runtime_d3d11::{D3D11InputView, D3D11OutputView};
     use std::slice;
     use std::time::Instant;
     use texture::ExampleTexture;
@@ -572,23 +571,11 @@ pub mod d3d11_hello_triangle {
                 self.filter
                     .frame(
                         None,
-                        D3D11InputView {
-                            handle: srv,
-                            size: Size {
-                                width: tex2d_desc.Width,
-                                height: tex2d_desc.Height,
-                            },
-                        },
+                        &srv,
                         &Viewport {
                             x: 0f32,
                             y: 0f32,
-                            output: D3D11OutputView {
-                                size: Size {
-                                    width: backbuffer_desc.Width,
-                                    height: backbuffer_desc.Height,
-                                },
-                                handle: resources.backbuffer_rtv.as_ref().unwrap().clone(),
-                            },
+                            output: resources.backbuffer_rtv.as_ref().unwrap().clone(),
                             mvp: None,
                         },
                         resources.frame_count,

--- a/librashader-runtime-d3d11/tests/triangle.rs
+++ b/librashader-runtime-d3d11/tests/triangle.rs
@@ -12,8 +12,7 @@ use librashader_runtime_d3d11::options::FilterChainOptionsD3D11;
 // const FILTER_PATH: &str =
 //     "../test/Mega_Bezel_Packs/Duimon-Mega-Bezel/Presets/Advanced/Nintendo_GBA_SP/GBA_SP-[ADV]-[LCD-GRID].slangp";
 
-const FILTER_PATH: &str =
-    "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp";
+const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-royale.slangp";
 
 // const FILTER_PATH: &str = "../test/slang-shaders/test/history.slangp";
 // const FILTER_PATH: &str = "../test/slang-shaders/test/feedback.slangp";
@@ -61,7 +60,7 @@ fn triangle_d3d11() {
         FILTER_PATH,
         Some(&FilterChainOptionsD3D11 {
             force_no_mipmaps: false,
-            disable_cache: false,
+            disable_cache: true,
         }),
         // replace below with 'None' for the triangle
         // None,

--- a/librashader-runtime-d3d12/src/texture.rs
+++ b/librashader-runtime-d3d12/src/texture.rs
@@ -8,8 +8,6 @@ use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT;
 pub struct D3D12InputImage {
     pub resource: ID3D12Resource,
     pub descriptor: D3D12_CPU_DESCRIPTOR_HANDLE,
-    pub size: Size<u32>,
-    pub format: DXGI_FORMAT,
 }
 
 #[derive(Clone)]
@@ -117,11 +115,12 @@ impl InputTexture {
         filter: FilterMode,
         wrap_mode: WrapMode,
     ) -> InputTexture {
+        let desc = unsafe { image.resource.GetDesc() };
         InputTexture {
             resource: image.resource,
             descriptor: InputDescriptor::Raw(image.descriptor),
-            size: image.size,
-            format: image.format,
+            size: Size::new(desc.Width as u32, desc.Height),
+            format: desc.Format,
             wrap_mode,
             filter,
         }

--- a/librashader-runtime-d3d12/src/util.rs
+++ b/librashader-runtime-d3d12/src/util.rs
@@ -21,6 +21,7 @@ use windows::Win32::Graphics::Direct3D12::{
     D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX,
 };
 use windows::Win32::Graphics::Dxgi::Common::*;
+use librashader_common::Size;
 
 /// wtf retroarch?
 const DXGI_FORMAT_EX_A4R4G4B4_UNORM: DXGI_FORMAT = DXGI_FORMAT(1000);
@@ -385,5 +386,20 @@ unsafe fn memcpy_subresource(
                 );
             }
         }
+    }
+}
+
+
+pub(crate) trait GetSize {
+    fn size(&self) -> Size<u32>;
+}
+
+impl GetSize for ID3D12Resource {
+    fn size(&self) -> Size<u32> {
+        let desc =  unsafe {
+            self.GetDesc()
+        };
+
+        Size::new(desc.Width as u32, desc.Height)
     }
 }

--- a/librashader-runtime-d3d12/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d12/tests/hello_triangle/mod.rs
@@ -624,11 +624,6 @@ pub mod d3d12_hello_triangle {
                     D3D12InputImage {
                         resource: resources.framebuffer.clone(),
                         descriptor: framebuffer,
-                        size: Size::new(
-                            resources.viewport.Width as u32,
-                            resources.viewport.Height as u32,
-                        ),
-                        format: DXGI_FORMAT_R8G8B8A8_UNORM,
                     },
                     &Viewport {
                         x: 0.0,

--- a/librashader-runtime-d3d12/tests/triangle.rs
+++ b/librashader-runtime-d3d12/tests/triangle.rs
@@ -6,12 +6,12 @@ use crate::hello_triangle::{DXSample, SampleCommandLine};
 fn triangle_d3d12() {
     let sample = hello_triangle::d3d12_hello_triangle::Sample::new(
         // "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
-        // "../test/shaders_slang/crt/crt-lottes.slangp",
+        "../test/shaders_slang/crt/crt-lottes.slangp",
         // "../test/basic.slangp",
         // "../test/shaders_slang/handheld/console-border/gbc-lcd-grid-v2.slangp",
         // "../test/Mega_Bezel_Packs/Duimon-Mega-Bezel/Presets/Advanced/Nintendo_GBA_SP/GBA_SP-[ADV]-[LCD-GRID]-[Night].slangp",
         // "../test/slang-shaders/test/feedback.slangp",
-        "../test/shaders_slang/test/history.slangp",
+        // "../test/shaders_slang/test/history.slangp",
         // "../test/shaders_slang/crt/crt-royale.slangp",
         // "../test/slang-shaders/vhs/VHSPro.slangp",
         &SampleCommandLine {

--- a/librashader/src/lib.rs
+++ b/librashader/src/lib.rs
@@ -259,7 +259,7 @@ pub mod runtime {
             options::{
                 FilterChainOptionsD3D11 as FilterChainOptions, FrameOptionsD3D11 as FrameOptions,
             },
-            D3D11InputView, D3D11OutputView, FilterChainD3D11 as FilterChain,
+            FilterChainD3D11 as FilterChain,
         };
     }
 


### PR DESCRIPTION
Rely on `GetDesc` where possible.

~~Unsure if I want to move forward with this though, it is an ABI breaking change for not that much gain. If we eventually don't care about breaking ABI like for #66, we could roll these changes with ABI version `2`.~~

This actually doesn't break ABI, unless we want to get rid of some dummy fields..
