### PR TITLE
Vulkan and D3D12 memory improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1774,6 +1775,7 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "gfx-maths",
+ "gpu-allocator 0.27.0",
  "librashader-cache",
  "librashader-common",
  "librashader-preprocess",
@@ -1781,6 +1783,7 @@ dependencies = [
  "librashader-reflect",
  "librashader-runtime",
  "mach-siegbert-vogt-dxcsa",
+ "parking_lot",
  "rayon",
  "thiserror",
  "widestring",

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -29,6 +29,8 @@ array-concat = "0.5.2"
 mach-siegbert-vogt-dxcsa = "0.1.3"
 
 rayon = "1.6.1"
+gpu-allocator = { version = "0.27.0", features = ["d3d12"], default-features = false}
+parking_lot = "0.12.3"
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/librashader-runtime-d3d12/src/buffer.rs
+++ b/librashader-runtime-d3d12/src/buffer.rs
@@ -1,19 +1,25 @@
 use crate::error;
-use crate::error::assume_d3d12_init;
+use gpu_allocator::d3d12::{
+    Allocator, Resource, ResourceCategory, ResourceCreateDesc, ResourceStateOrBarrierLayout,
+    ResourceType,
+};
+use gpu_allocator::MemoryLocation;
+use parking_lot::Mutex;
 use std::ffi::c_void;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut, Range};
 use std::ptr::NonNull;
+use std::sync::Arc;
 use windows::Win32::Graphics::Direct3D12::{
-    ID3D12Device, ID3D12GraphicsCommandList, ID3D12Resource, D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-    D3D12_HEAP_FLAG_NONE, D3D12_HEAP_PROPERTIES, D3D12_HEAP_TYPE_UPLOAD, D3D12_MEMORY_POOL_UNKNOWN,
-    D3D12_RANGE, D3D12_RESOURCE_DESC, D3D12_RESOURCE_DIMENSION_BUFFER,
-    D3D12_RESOURCE_STATE_GENERIC_READ, D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+    ID3D12GraphicsCommandList, ID3D12Resource, D3D12_RANGE, D3D12_RESOURCE_DESC,
+    D3D12_RESOURCE_DIMENSION_BUFFER, D3D12_RESOURCE_STATE_GENERIC_READ,
+    D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
 };
 use windows::Win32::Graphics::Dxgi::Common::DXGI_SAMPLE_DESC;
 
 pub struct D3D12Buffer {
-    handle: ID3D12Resource,
+    resource: ManuallyDrop<Resource>,
+    allocator: Arc<Mutex<Allocator>>,
     size: usize,
 }
 
@@ -28,51 +34,51 @@ impl<'a> Drop for D3D12BufferMapHandle<'a> {
     }
 }
 
-impl D3D12Buffer {
-    pub fn new(device: &ID3D12Device, size: usize) -> error::Result<D3D12Buffer> {
-        unsafe {
-            let mut buffer: Option<ID3D12Resource> = None;
-            device.CreateCommittedResource(
-                &D3D12_HEAP_PROPERTIES {
-                    Type: D3D12_HEAP_TYPE_UPLOAD,
-                    CPUPageProperty: D3D12_CPU_PAGE_PROPERTY_UNKNOWN,
-                    MemoryPoolPreference: D3D12_MEMORY_POOL_UNKNOWN,
-                    ..Default::default()
-                },
-                D3D12_HEAP_FLAG_NONE,
-                &D3D12_RESOURCE_DESC {
-                    Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
-                    Width: size as u64,
-                    Height: 1,
-                    DepthOrArraySize: 1,
-                    MipLevels: 1,
-                    Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-                    SampleDesc: DXGI_SAMPLE_DESC {
-                        Count: 1,
-                        Quality: 0,
-                    },
-                    ..Default::default()
-                },
-                D3D12_RESOURCE_STATE_GENERIC_READ,
-                None,
-                &mut buffer,
-            )?;
-
-            assume_d3d12_init!(buffer, "CreateCommittedResource");
-
-            Ok(D3D12Buffer {
-                handle: buffer,
-                size,
-            })
+impl Drop for D3D12Buffer {
+    fn drop(&mut self) {
+        let resource = unsafe { ManuallyDrop::take(&mut self.resource) };
+        if let Err(e) = self.allocator.lock().free_resource(resource) {
+            println!("librashader-runtime-d3d12: [warn] failed to deallocate buffer memory {e}")
         }
+    }
+}
+
+impl D3D12Buffer {
+    pub fn new(allocator: &Arc<Mutex<Allocator>>, size: usize) -> error::Result<D3D12Buffer> {
+        let resource = allocator.lock().create_resource(&ResourceCreateDesc {
+            name: "d3d12buffer",
+            memory_location: MemoryLocation::CpuToGpu,
+            resource_category: ResourceCategory::Buffer,
+            resource_desc: &D3D12_RESOURCE_DESC {
+                Dimension: D3D12_RESOURCE_DIMENSION_BUFFER,
+                Width: size as u64,
+                Height: 1,
+                DepthOrArraySize: 1,
+                MipLevels: 1,
+                Layout: D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
+                ..Default::default()
+            },
+            castable_formats: &[],
+            clear_value: None,
+            initial_state_or_layout: ResourceStateOrBarrierLayout::ResourceState(
+                D3D12_RESOURCE_STATE_GENERIC_READ,
+            ),
+            resource_type: &ResourceType::Placed,
+        })?;
+
+        Ok(Self {
+            resource: ManuallyDrop::new(resource),
+            size,
+            allocator: Arc::clone(&allocator),
+        })
     }
 
     pub fn gpu_address(&self) -> u64 {
-        unsafe { self.handle.GetGPUVirtualAddress() }
-    }
-
-    pub fn into_raw(self) -> ID3D12Resource {
-        self.handle
+        unsafe { self.resource.resource().GetGPUVirtualAddress() }
     }
 
     pub fn map(&mut self, range: Option<Range<usize>>) -> error::Result<D3D12BufferMapHandle> {
@@ -88,10 +94,12 @@ impl D3D12Buffer {
 
         unsafe {
             let mut ptr = std::ptr::null_mut();
-            self.handle.Map(0, Some(&range), Some(&mut ptr))?;
+            self.resource
+                .resource()
+                .Map(0, Some(&range), Some(&mut ptr))?;
             let slice = std::slice::from_raw_parts_mut(ptr.cast(), size);
             Ok(D3D12BufferMapHandle {
-                handle: &self.handle,
+                handle: &self.resource.resource(),
                 slice,
             })
         }
@@ -115,7 +123,10 @@ impl RawD3D12Buffer {
         let range = D3D12_RANGE { Begin: 0, End: 0 };
         let mut ptr = std::ptr::null_mut();
         unsafe {
-            buffer.handle.Map(0, Some(&range), Some(&mut ptr))?;
+            buffer
+                .resource
+                .resource()
+                .Map(0, Some(&range), Some(&mut ptr))?;
         }
 
         // panic-safety: If Map returns Ok then ptr is not null
@@ -134,7 +145,7 @@ impl RawD3D12Buffer {
 impl Drop for RawD3D12Buffer {
     fn drop(&mut self) {
         unsafe {
-            self.buffer.handle.Unmap(0, None);
+            self.buffer.resource.resource().Unmap(0, None);
             ManuallyDrop::drop(&mut self.buffer);
         }
     }

--- a/librashader-runtime-d3d12/src/error.rs
+++ b/librashader-runtime-d3d12/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// Cumulative error type for Direct3D12 filter chains.
 #[derive(Error, Debug)]
 pub enum FilterChainError {
-    #[error("invariant assumption about d3d11 did not hold. report this as an issue.")]
+    #[error("invariant assumption about d3d12 did not hold. report this as an issue.")]
     Direct3DOperationError(&'static str),
     #[error("direct3d driver error")]
     Direct3DError(#[from] windows::core::Error),
@@ -21,6 +21,8 @@ pub enum FilterChainError {
     LutLoadError(#[from] ImageError),
     #[error("heap overflow")]
     DescriptorHeapOverflow(usize),
+    #[error("allocation error")]
+    AllocationError(#[from] gpu_allocator::AllocationError),
 }
 
 /// Result type for Direct3D 12 filter chains.

--- a/librashader-runtime-d3d12/tests/triangle.rs
+++ b/librashader-runtime-d3d12/tests/triangle.rs
@@ -6,11 +6,11 @@ use crate::hello_triangle::{DXSample, SampleCommandLine};
 fn triangle_d3d12() {
     let sample = hello_triangle::d3d12_hello_triangle::Sample::new(
         // "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
-        "../test/shaders_slang/crt/crt-lottes.slangp",
+        // "../test/shaders_slang/crt/crt-lottes.slangp",
         // "../test/basic.slangp",
         // "../test/shaders_slang/handheld/console-border/gbc-lcd-grid-v2.slangp",
         // "../test/Mega_Bezel_Packs/Duimon-Mega-Bezel/Presets/Advanced/Nintendo_GBA_SP/GBA_SP-[ADV]-[LCD-GRID]-[Night].slangp",
-        // "../test/slang-shaders/test/feedback.slangp",
+        "../test/shaders_slang/test/feedback.slangp",
         // "../test/shaders_slang/test/history.slangp",
         // "../test/shaders_slang/crt/crt-royale.slangp",
         // "../test/slang-shaders/vhs/VHSPro.slangp",

--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -9,7 +9,7 @@ use crate::options::{FilterChainOptionsVulkan, FrameOptionsVulkan};
 use crate::queue_selection::get_graphics_queue;
 use crate::samplers::SamplerSet;
 use crate::texture::{InputImage, OwnedImage, OwnedImageLayout, VulkanImage};
-use crate::{error, util};
+use crate::{error, memory, util};
 use ash::vk;
 use librashader_common::{ImageFormat, Size, Viewport};
 
@@ -80,7 +80,7 @@ impl TryFrom<VulkanInstance> for VulkanObjects {
             // let memory_properties =
             //     instance.get_physical_device_memory_properties(vulkan.physical_device);
 
-            let alloc = util::create_allocator(device.clone(), instance, vulkan.physical_device)?;
+            let alloc = memory::create_allocator(device.clone(), instance, vulkan.physical_device)?;
 
             Ok(VulkanObjects {
                 device: Arc::new(device),
@@ -103,7 +103,7 @@ impl TryFrom<(vk::PhysicalDevice, ash::Instance, ash::Device)> for VulkanObjects
 
         // let memory_properties = value.1.get_physical_device_memory_properties(value.0);
 
-        let alloc = util::create_allocator(device.clone(), value.1, value.0)?;
+        let alloc = memory::create_allocator(device.clone(), value.1, value.0)?;
 
         Ok(VulkanObjects {
             alloc,

--- a/librashader-runtime-vk/src/memory.rs
+++ b/librashader-runtime-vk/src/memory.rs
@@ -1,8 +1,10 @@
 use crate::error;
 use crate::error::FilterChainError;
 use ash::vk;
-use gpu_allocator::vulkan::{Allocation, AllocationCreateDesc, AllocationScheme, Allocator};
-use gpu_allocator::MemoryLocation;
+use gpu_allocator::vulkan::{
+    Allocation, AllocationCreateDesc, AllocationScheme, Allocator, AllocatorCreateDesc,
+};
+use gpu_allocator::{AllocationSizes, MemoryLocation};
 use librashader_runtime::uniforms::UniformStorageAccess;
 use parking_lot::Mutex;
 
@@ -56,7 +58,7 @@ impl Drop for VulkanImageMemory {
 pub struct VulkanBuffer {
     pub handle: vk::Buffer,
     device: Arc<ash::Device>,
-    memory: Option<Allocation>,
+    allocation: ManuallyDrop<Allocation>,
     allocator: Arc<Mutex<Allocator>>,
     size: vk::DeviceSize,
 }
@@ -85,12 +87,11 @@ impl VulkanBuffer {
                 allocation_scheme: AllocationScheme::DedicatedBuffer(buffer),
             })?;
 
-            // let alloc = device.allocate_memory(&alloc_info, None)?;
             device.bind_buffer_memory(buffer, alloc.memory(), 0)?;
 
             Ok(VulkanBuffer {
                 handle: buffer,
-                memory: Some(alloc),
+                allocation: ManuallyDrop::new(alloc),
                 allocator: Arc::clone(allocator),
                 size: size as vk::DeviceSize,
                 device: device.clone(),
@@ -99,10 +100,7 @@ impl VulkanBuffer {
     }
 
     pub fn as_mut_slice(&mut self) -> error::Result<&mut [u8]> {
-        let Some(allocation) = self.memory.as_mut() else {
-            return Err(FilterChainError::AllocationDoesNotExist);
-        };
-        let Some(allocation) = allocation.mapped_slice_mut() else {
+        let Some(allocation) = self.allocation.mapped_slice_mut() else {
             return Err(FilterChainError::AllocationDoesNotExist);
         };
         Ok(allocation)
@@ -112,12 +110,10 @@ impl VulkanBuffer {
 impl Drop for VulkanBuffer {
     fn drop(&mut self) {
         unsafe {
-            if let Some(allocation) = self.memory.take() {
-                if let Err(e) = self.allocator.lock().free(allocation) {
-                    println!(
-                        "librashader-runtime-vk: [warn] failed to deallocate buffer memory {e}"
-                    )
-                }
+            // SAFETY: things can not be double dropped.
+            let allocation = ManuallyDrop::take(&mut self.allocation);
+            if let Err(e) = self.allocator.lock().free(allocation) {
+                println!("librashader-runtime-vk: [warn] failed to deallocate buffer memory {e}")
             }
 
             if self.handle != vk::Buffer::null() {
@@ -147,7 +143,7 @@ impl RawVulkanBuffer {
     ) -> error::Result<Self> {
         let buffer = ManuallyDrop::new(VulkanBuffer::new(device, allocator, usage, size)?);
 
-        let Some(ptr) = buffer.memory.as_ref().map(|m| m.mapped_ptr()).flatten() else {
+        let Some(ptr) = buffer.allocation.mapped_ptr() else {
             return Err(FilterChainError::AllocationDoesNotExist);
         };
 
@@ -203,4 +199,45 @@ impl DerefMut for RawVulkanBuffer {
             std::slice::from_raw_parts_mut(self.ptr.as_ptr().cast(), self.buffer.size as usize)
         }
     }
+}
+
+#[allow(unused)]
+pub fn find_vulkan_memory_type(
+    props: &vk::PhysicalDeviceMemoryProperties,
+    device_reqs: u32,
+    host_reqs: vk::MemoryPropertyFlags,
+) -> error::Result<u32> {
+    for i in 0..vk::MAX_MEMORY_TYPES {
+        if device_reqs & (1 << i) != 0
+            && props.memory_types[i].property_flags & host_reqs == host_reqs
+        {
+            return Ok(i as u32);
+        }
+    }
+
+    if host_reqs == vk::MemoryPropertyFlags::empty() {
+        Err(FilterChainError::VulkanMemoryError(device_reqs))
+    } else {
+        Ok(find_vulkan_memory_type(
+            props,
+            device_reqs,
+            vk::MemoryPropertyFlags::empty(),
+        )?)
+    }
+}
+
+pub fn create_allocator(
+    device: ash::Device,
+    instance: ash::Instance,
+    physical_device: vk::PhysicalDevice,
+) -> error::Result<Arc<Mutex<Allocator>>> {
+    let alloc = Allocator::new(&AllocatorCreateDesc {
+        instance,
+        device,
+        physical_device,
+        debug_settings: Default::default(),
+        buffer_device_address: false,
+        allocation_sizes: AllocationSizes::default(),
+    })?;
+    Ok(Arc::new(Mutex::new(alloc)))
 }


### PR DESCRIPTION
* Use `ManuallyDrop` for Vulkan buffer rather than Option
* Use `gpu_allocator` to suballocate buffers rather than `CreateCommittedResource`