### PR TITLE
capi: add missing const-qualifier to __librashader__noop_*_filter_chain_get_param

### DIFF
--- a/include/librashader_ld.h
+++ b/include/librashader_ld.h
@@ -224,7 +224,7 @@ libra_error_t __librashader__noop_gl_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_gl_filter_chain_get_param(
-    libra_gl_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_gl_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 
@@ -274,7 +274,7 @@ libra_error_t __librashader__noop_vk_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_vk_filter_chain_get_param(
-    libra_vk_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_vk_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 
@@ -326,7 +326,7 @@ libra_error_t __librashader__noop_d3d11_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_d3d11_filter_chain_get_param(
-    libra_d3d11_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_d3d11_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 
@@ -378,7 +378,7 @@ libra_error_t __librashader__noop_d3d12_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_d3d12_filter_chain_get_param(
-    libra_d3d12_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_d3d12_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 
@@ -421,7 +421,7 @@ libra_error_t __librashader__noop_d3d9_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_d3d9_filter_chain_get_param(
-    libra_d3d9_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_d3d9_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 
@@ -473,7 +473,7 @@ libra_error_t __librashader__noop_mtl_filter_chain_set_param(
 }
 
 libra_error_t __librashader__noop_mtl_filter_chain_get_param(
-    libra_mtl_filter_chain_t *chain, const char *param_name, float *out) {
+    const libra_mtl_filter_chain_t *chain, const char *param_name, float *out) {
     return NULL;
 }
 


### PR DESCRIPTION
The `libra_*_filter_chain_t *chain` parameter of the `__librashader__noop_*_filter_chain_get_param` functions in the `librashader_ld.h` header require the `const`-qualifier after commit https://github.com/SnowflakePowered/librashader/commit/c447e405831b692ff12d62fe1157041d4a2ad29a.

Otherwise compilation of consumers like the ares emulator fails with the following error:
```
/usr/local/include/librashader/librashader_ld.h:1458:9: error: assigning to 'PFN_libra_gl_filter_chain_get_param' (aka '_libra_error *(*)(_filter_chain_gl *const *, const char *, float *)') from incompatible type 'libra_error_t (libra_gl_filter_chain_t *, const char *, float *)' (aka '_libra_error *(_filter_chain_gl **, const char *, float *)'): type mismatch at 1st parameter ('const libra_gl_filter_chain_t *' (aka '_filter_chain_gl *const *') vs 'libra_gl_filter_chain_t *' (aka '_filter_chain_gl **'))
 1458 |         __librashader__noop_gl_filter_chain_get_param;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```