### PR TITLE
capi: remove dependency on `try_blocks`

### DIFF
--- a/librashader-capi/src/error.rs
+++ b/librashader-capi/src/error.rs
@@ -211,12 +211,12 @@ impl LibrashaderError {
 }
 
 macro_rules! assert_non_null {
-    ($value:ident) => {
+    (@EXPORT $value:ident) => {
         if $value.is_null() || !$crate::ffi::ptr_is_aligned($value) {
             return $crate::error::LibrashaderError::InvalidParameter(stringify!($value)).export();
         }
     };
-    (noexport $value:ident) => {
+    ($value:ident) => {
         if $value.is_null() || !$crate::ffi::ptr_is_aligned($value) {
             return Err($crate::error::LibrashaderError::InvalidParameter(
                 stringify!($value),
@@ -228,14 +228,18 @@ macro_rules! assert_non_null {
 macro_rules! assert_some_ptr {
     ($value:ident) => {
         if $value.is_none() {
-            return $crate::error::LibrashaderError::InvalidParameter(stringify!($value)).export();
+            return Err($crate::error::LibrashaderError::InvalidParameter(
+                stringify!($value),
+            ));
         }
 
         let $value = unsafe { $value.as_ref().unwrap_unchecked().as_ref() };
     };
     (mut $value:ident) => {
         if $value.is_none() {
-            return $crate::error::LibrashaderError::InvalidParameter(stringify!($value)).export();
+            return Err($crate::error::LibrashaderError::InvalidParameter(
+                stringify!($value),
+            ));
         }
 
         let $value = unsafe { $value.as_mut().unwrap_unchecked().as_mut() };

--- a/librashader-capi/src/ffi.rs
+++ b/librashader-capi/src/ffi.rs
@@ -1,9 +1,16 @@
+#[macro_export]
+macro_rules! wrap_ok {
+    ($e:expr) => {
+        ::core::iter::empty().try_fold($e, |_, __x: ::core::convert::Infallible| match __x {})
+    };
+}
+
 macro_rules! ffi_body {
     (nopanic $body:block) => {
         {
-            let result: Result<(), $crate::error::LibrashaderError> = try {
+            let result: Result<(), $crate::error::LibrashaderError> = (|| $crate::ffi::wrap_ok!({
                 $body
-            };
+            }))();
 
             let Err(e) = result else {
                 return $crate::error::LibrashaderError::ok()
@@ -22,13 +29,13 @@ macro_rules! ffi_body {
     };
     (nopanic |$($ref_capture:ident),*|; mut |$($mut_capture:ident),*| $body:block) => {
         {
-            $($crate::error::assert_non_null!($ref_capture);)*
+            $($crate::error::assert_non_null!(@EXPORT $ref_capture);)*
             $(let $ref_capture = unsafe { &*$ref_capture };)*
-            $($crate::error::assert_non_null!($mut_capture);)*
+            $($crate::error::assert_non_null!(@EXPORT $mut_capture);)*
             $(let $mut_capture = unsafe { &mut *$mut_capture };)*
-            let result: Result<(), $crate::error::LibrashaderError> = try {
+            let result: Result<(), $crate::error::LibrashaderError> = (|| $crate::ffi::wrap_ok!({
                 $body
-            };
+            }))();
 
             let Err(e) = result else {
                 return $crate::error::LibrashaderError::ok()
@@ -47,11 +54,11 @@ macro_rules! ffi_body {
     };
     (nopanic mut |$($mut_capture:ident),*| $body:block) => {
         {
-            $($crate::error::assert_non_null!($mut_capture);)*
+            $($crate::error::assert_non_null!(@EXPORT $mut_capture);)*
             $(let $mut_capture = unsafe { &mut *$mut_capture };)*
-            let result: Result<(), $crate::error::LibrashaderError> = try {
+            let result: Result<(), $crate::error::LibrashaderError> = (|| $crate::ffi::wrap_ok!({
                 $body
-            };
+            }))();
 
             let Err(e) = result else {
                 return $crate::error::LibrashaderError::ok()
@@ -70,11 +77,11 @@ macro_rules! ffi_body {
     };
     (nopanic |$($ref_capture:ident),*| $body:block) => {
         {
-            $($crate::error::assert_non_null!($ref_capture);)*
+            $($crate::error::assert_non_null!(@EXPORT $ref_capture);)*
             $(let $ref_capture = unsafe { &*$ref_capture };)*
-            let result: Result<(), $crate::error::LibrashaderError> = try {
+            let result: Result<(), $crate::error::LibrashaderError> = (|| $crate::ffi::wrap_ok!({
                 $body
-            };
+            }))();
 
             let Err(e) = result else {
                 return $crate::error::LibrashaderError::ok()
@@ -231,16 +238,16 @@ pub unsafe fn boxed_slice_from_raw_parts<T>(ptr: *mut T, len: usize) -> Box<[T]>
     unsafe { Box::from_raw(std::slice::from_raw_parts_mut(ptr, len)) }
 }
 
-#[allow(unstable_name_collisions)]
 pub fn ptr_is_aligned<T: Sized>(ptr: *const T) -> bool {
-    use sptr::Strict;
     let align = std::mem::align_of::<T>();
     if !align.is_power_of_two() {
         panic!("is_aligned_to: align is not a power-of-two");
     }
-    ptr.addr() & (align - 1) == 0
+    sptr::Strict::addr(ptr) & (align - 1) == 0
 }
 
 pub(crate) use extern_fn;
 pub(crate) use ffi_body;
+pub(crate) use wrap_ok;
+
 use std::mem::ManuallyDrop;

--- a/librashader-capi/src/lib.rs
+++ b/librashader-capi/src/lib.rs
@@ -64,7 +64,6 @@
 //! called from one thread at a time.
 
 #![allow(non_camel_case_types)]
-#![feature(try_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(deprecated)]
 

--- a/librashader-capi/src/runtime/d3d11/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d11/filter_chain.rs
@@ -268,7 +268,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -293,7 +293,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));

--- a/librashader-capi/src/runtime/d3d12/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d12/filter_chain.rs
@@ -288,7 +288,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -313,7 +313,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));

--- a/librashader-capi/src/runtime/d3d9/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d9/filter_chain.rs
@@ -178,7 +178,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -203,7 +203,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));

--- a/librashader-capi/src/runtime/gl/filter_chain.rs
+++ b/librashader-capi/src/runtime/gl/filter_chain.rs
@@ -235,7 +235,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -260,7 +260,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));

--- a/librashader-capi/src/runtime/mtl/filter_chain.rs
+++ b/librashader-capi/src/runtime/mtl/filter_chain.rs
@@ -236,7 +236,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -261,7 +261,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));

--- a/librashader-capi/src/runtime/vk/filter_chain.rs
+++ b/librashader-capi/src/runtime/vk/filter_chain.rs
@@ -314,7 +314,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             if chain.parameters().set_parameter_value(name, value).is_none() {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             }
         }
     }
@@ -339,7 +339,7 @@ extern_fn! {
             let name = name.to_str()?;
 
             let Some(value) = chain.parameters().parameter_value(name) else {
-                return LibrashaderError::UnknownShaderParameter(param_name).export()
+                return Err(LibrashaderError::UnknownShaderParameter(param_name))
             };
 
             out.write(MaybeUninit::new(value));


### PR DESCRIPTION
Uses an IIFE + return type changes to remove the need for try blocks

Allows us to remove another nightly feature needed