### PR TITLE
Allow using trait objects for CompileReflectShader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,12 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned-vec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,33 +106,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
-
-[[package]]
-name = "arbitrary"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
-
-[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
 
 [[package]]
 name = "array-concat"
@@ -154,9 +125,9 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -231,29 +202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "av1-grain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame",
-]
-
-[[package]]
-name = "avif-serialize"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,12 +242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,12 +252,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bitstream-io"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452"
 
 [[package]]
 name = "bitvec"
@@ -390,12 +326,6 @@ name = "build-target"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
-
-[[package]]
-name = "built"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
 
 [[package]]
 name = "bumpalo"
@@ -480,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
 dependencies = [
  "clap 3.2.25",
- "heck 0.4.1",
+ "heck",
  "indexmap 1.9.3",
  "log",
  "proc-macro2",
@@ -489,14 +419,14 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "tempfile",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.17"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93fe60e2fc87b6ba2c117f67ae14f66e3fc7d6a1e612a25adb238cc980eadb3"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
@@ -508,16 +438,6 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cfg-expr"
-version = "0.15.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
 
 [[package]]
 name = "cfg-if"
@@ -567,7 +487,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -712,7 +632,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "yaml-rust",
 ]
 
@@ -819,12 +739,6 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -989,22 +903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
-dependencies = [
- "bit_field",
- "flume",
- "half",
- "lebe",
- "miniz_oxide 0.7.4",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,15 +931,6 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "spin",
 ]
 
 [[package]]
@@ -1307,16 +1196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
-
-[[package]]
 name = "halfbrown"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,12 +1245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,15 +1291,10 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
- "exr",
  "gif",
  "image-webp",
  "num-traits",
  "png",
- "qoi",
- "ravif",
- "rayon",
- "rgb",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -1441,12 +1309,6 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
-
-[[package]]
-name = "imgref"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "indexmap"
@@ -1469,17 +1331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,15 +1339,6 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1586,27 +1428,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
-
-[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
-dependencies = [
- "arbitrary",
- "cc",
- "once_cell",
-]
 
 [[package]]
 name = "libloading"
@@ -1900,7 +1725,6 @@ dependencies = [
  "bytemuck",
  "config",
  "env_logger",
- "image",
  "librashader-cache",
  "librashader-common",
  "librashader-preprocess",
@@ -1972,15 +1796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "loop9"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
-dependencies = [
- "imgref",
-]
-
-[[package]]
 name = "mach-siegbert-vogt-dxcsa"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,15 +1820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,9 +1827,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -2122,12 +1928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,12 +1947,6 @@ dependencies = [
  "memchr",
  "nom",
 ]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num"
@@ -2399,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "orbclient"
@@ -2455,7 +2249,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2675,28 +2469,6 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
-dependencies = [
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "quick-error"
@@ -2763,55 +2535,6 @@ name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
-
-[[package]]
-name = "rav1e"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
-dependencies = [
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av1-grain",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "once_cell",
- "paste",
- "profiling",
- "rand",
- "rand_chacha",
- "simd_helpers",
- "system-deps",
- "thiserror",
- "v_frame",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ravif"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f0bfd976333248de2078d350bfdf182ff96e168a24d23d2436cef320dd4bdd"
-dependencies = [
- "avif-serialize",
- "imgref",
- "loop9",
- "quick-error",
- "rav1e",
- "rgb",
-]
 
 [[package]]
 name = "raw-window-handle"
@@ -2886,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2940,15 +2663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
-name = "rgb"
-version = "0.8.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "ron"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,9 +2707,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3077,15 +2791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,15 +2812,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
 
 [[package]]
 name = "slab"
@@ -3187,15 +2883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3219,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-cross2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb82b382354d130f8cd362529f88465cf9ba30c5878af80ea64f2d073e297df4"
+checksum = "ca2c78dd7b37f600f6254e95c435b81f5f0201b96d26e263646999f7a3669c19"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -3313,29 +3000,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-deps"
-version = "6.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
-dependencies = [
- "cfg-expr",
- "heck 0.5.0",
- "pkg-config",
- "toml 0.8.19",
- "version-compare",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -3431,25 +3099,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -3458,8 +3111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap 2.5.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -3500,15 +3151,15 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3529,27 +3180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
-name = "v_frame"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "vec_extract_if_polyfill"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c9cb5fb67c2692310b6eb3fce7dd4b6e4c9a75be4f2f46b27f0b2b7799759c"
-
-[[package]]
-name = "version-compare"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -4346,9 +3980,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a77ee7c0de333dcc6da69b177380a0b81e0dacfa4f7344c465a36871ee601"
+checksum = "af4e2e2f7cba5a093896c1e150fbfe177d1883e7448200efb81d40b9d339ef26"
 
 [[package]]
 name = "yaml-rust"
@@ -4394,15 +4028,6 @@ name = "zune-core"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "zune-jpeg"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Windows and macOS users can grab the latest binaries from [GitHub Releases](http
 librashader supports all modern graphics runtimes, including wgpu, Vulkan, OpenGL 3.3+ and 4.6 (with DSA), 
 Direct3D 11, Direct3D 12, and Metal. 
 
-librashader does not support legacy render APIs such as older versions of OpenGL or Direct3D, except for experimental
+librashader does not support legacy render APIs such as older versions of OpenGL or Direct3D, except for limited
 support for Direct3D 9.
 
 | **API**     | **Status** | **`librashader` feature** |

--- a/librashader-capi/Cargo.toml
+++ b/librashader-capi/Cargo.toml
@@ -26,6 +26,7 @@ runtime-vulkan = ["ash", "librashader/runtime-vk"]
 runtime-metal = ["__cbindgen_internal_objc", "librashader/runtime-metal"]
 
 reflect-unstable = []
+stable = ["librashader/stable"]
 
 __cbindgen_internal = ["runtime-all"]
 

--- a/librashader-capi/Cargo.toml
+++ b/librashader-capi/Cargo.toml
@@ -27,6 +27,7 @@ runtime-metal = ["__cbindgen_internal_objc", "librashader/runtime-metal"]
 
 reflect-unstable = []
 stable = ["librashader/stable"]
+docsrs = []
 
 __cbindgen_internal = ["runtime-all"]
 
@@ -66,4 +67,4 @@ targets = [ "x86_64-pc-windows-msvc",
     "aarch64-apple-ios",
     "i686-pc-windows-msvc",
     "i686-unknown-linux-gnu", ]
-features = ["librashader/docsrs"]
+features = ["docsrs", "librashader/docsrs"]

--- a/librashader-capi/src/ctypes.rs
+++ b/librashader-capi/src/ctypes.rs
@@ -60,7 +60,7 @@ use librashader::runtime::gl::FilterChain as FilterChainGL;
 
 /// A handle to a OpenGL filter chain.
 #[cfg(feature = "runtime-opengl")]
-#[doc(cfg(feature = "runtime-opengl"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-opengl")))]
 pub type libra_gl_filter_chain_t = Option<NonNull<FilterChainGL>>;
 
 /// A handle to a Direct3D 11 filter chain.
@@ -71,7 +71,10 @@ pub type libra_gl_filter_chain_t = Option<NonNull<FilterChainGL>>;
 use librashader::runtime::d3d11::FilterChain as FilterChainD3D11;
 
 /// A handle to a Direct3D 11 filter chain.
-#[doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(target_os = "windows", feature = "runtime-d3d11")
@@ -98,7 +101,10 @@ pub type libra_d3d12_filter_chain_t = Option<NonNull<FilterChainD3D12>>;
 use librashader::runtime::d3d9::FilterChain as FilterChainD3D9;
 
 /// A handle to a Direct3D 11 filter chain.
-#[doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(target_os = "windows", feature = "runtime-d3d9")
@@ -109,12 +115,15 @@ pub type libra_d3d9_filter_chain_t = Option<NonNull<FilterChainD3D9>>;
 use librashader::runtime::vk::FilterChain as FilterChainVulkan;
 /// A handle to a Vulkan filter chain.
 #[cfg(feature = "runtime-vulkan")]
-#[doc(cfg(feature = "runtime-vulkan"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-vulkan")))]
 pub type libra_vk_filter_chain_t = Option<NonNull<FilterChainVulkan>>;
 
 #[cfg(all(target_os = "macos", feature = "runtime-metal"))]
 use librashader::runtime::mtl::FilterChain as FilterChainMetal;
-#[doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(

--- a/librashader-capi/src/error.rs
+++ b/librashader-capi/src/error.rs
@@ -26,26 +26,38 @@ pub enum LibrashaderError {
     #[error("The provided parameter name was invalid.")]
     UnknownShaderParameter(*const c_char),
     #[cfg(feature = "runtime-opengl")]
-    #[doc(cfg(feature = "runtime-opengl"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-opengl")))]
     #[error("There was an error in the OpenGL filter chain.")]
     OpenGlFilterError(#[from] librashader::runtime::gl::error::FilterChainError),
     #[cfg(all(target_os = "windows", feature = "runtime-d3d11"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))
+    )]
     #[error("There was an error in the D3D11 filter chain.")]
     D3D11FilterError(#[from] librashader::runtime::d3d11::error::FilterChainError),
     #[cfg(all(target_os = "windows", feature = "runtime-d3d12"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))
+    )]
     #[error("There was an error in the D3D12 filter chain.")]
     D3D12FilterError(#[from] librashader::runtime::d3d12::error::FilterChainError),
     #[cfg(all(target_os = "windows", feature = "runtime-d3d9"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))
+    )]
     #[error("There was an error in the D3D9 filter chain.")]
     D3D9FilterError(#[from] librashader::runtime::d3d9::error::FilterChainError),
     #[cfg(feature = "runtime-vulkan")]
-    #[doc(cfg(feature = "runtime-vulkan"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-vulkan")))]
     #[error("There was an error in the Vulkan filter chain.")]
     VulkanFilterError(#[from] librashader::runtime::vk::error::FilterChainError),
-    #[doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))
+    )]
     #[cfg(all(target_vendor = "apple", feature = "runtime-metal"))]
     #[error("There was an error in the D3D12 filter chain.")]
     MetalFilterError(#[from] librashader::runtime::mtl::error::FilterChainError),

--- a/librashader-capi/src/lib.rs
+++ b/librashader-capi/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(doc_cfg)]
 //! The C API for [librashader](https://docs.rs/librashader/).
 //!
 //! The librashader C API is designed to be loaded dynamically via `librashader_ld.h`, but static usage is also
@@ -62,7 +61,7 @@
 //!
 //! You must ensure that only thread has access to a created filter pass **before** you call `*_frame`. `*_frame` may only be
 //! called from one thread at a time.
-
+#![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 #![allow(non_camel_case_types)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(deprecated)]

--- a/librashader-capi/src/runtime/mod.rs
+++ b/librashader-capi/src/runtime/mod.rs
@@ -1,34 +1,46 @@
 //! librashader runtime C APIs.
-#[doc(cfg(feature = "runtime-opengl"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-opengl")))]
 #[cfg(feature = "runtime-opengl")]
 pub mod gl;
 
-#[doc(cfg(feature = "runtime-vulkan"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-vulkan")))]
 #[cfg(feature = "runtime-vulkan")]
 pub mod vk;
 
-#[doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(target_os = "windows", feature = "runtime-d3d11")
 ))]
 pub mod d3d11;
 
-#[doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(target_os = "windows", feature = "runtime-d3d9")
 ))]
 pub mod d3d9;
 
-#[doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(target_os = "windows", feature = "runtime-d3d12")
 ))]
 pub mod d3d12;
 
-#[doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))]
+#[cfg_attr(
+    feature = "docsrs",
+    doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))
+)]
 #[cfg(any(
     feature = "__cbindgen_internal",
     all(

--- a/librashader-reflect/Cargo.toml
+++ b/librashader-reflect/Cargo.toml
@@ -46,5 +46,6 @@ cross = [ "dep:spirv-cross2", "spirv-cross2/glsl", "spirv-cross2/hlsl", "spirv-c
 naga = [ "dep:rspirv", "dep:spirv", "naga/spv-in", "naga/spv-out", "naga/wgsl-out", "naga/msl-out" ]
 serialize = [ "dep:serde" ]
 msl = [ "spirv-cross2/msl", "naga/msl-out" ]
+stable = []
 
 unstable-naga-in = ["naga/glsl-in"]

--- a/librashader-reflect/src/back/glsl.rs
+++ b/librashader-reflect/src/back/glsl.rs
@@ -1,9 +1,8 @@
 use crate::back::targets::GLSL;
-use crate::back::{CompileShader, CompilerBackend, FromCompilation};
+use crate::back::{CompileReflectShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::{CompiledProgram, SpirvCross};
-use crate::reflect::ReflectShader;
 
 /// The GLSL version to target.
 pub use spirv_cross2::compile::glsl::GlslVersion;
@@ -22,8 +21,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     type Target = GLSL;
     type Options = GlslVersion;
     type Context = CrossGlslContext;
-    type Output = impl CompileShader<Self::Target, Options = GlslVersion, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/back/glsl.rs
+++ b/librashader-reflect/src/back/glsl.rs
@@ -17,6 +17,7 @@ pub struct CrossGlslContext {
     pub artifact: CompiledProgram<spirv_cross2::targets::Glsl>,
 }
 
+#[cfg(not(feature = "stable"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     type Target = GLSL;
     type Options = GlslVersion;
@@ -28,6 +29,22 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
             backend: GlslReflect::try_from(&compile)?,
+        })
+    }
+}
+
+#[cfg(feature = "stable")]
+impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
+    type Target = GLSL;
+    type Options = GlslVersion;
+    type Context = CrossGlslContext;
+    type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross> + Send>;
+
+    fn from_compilation(
+        compile: SpirvCompilation,
+    ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
+        Ok(CompilerBackend {
+            backend: Box::new(GlslReflect::try_from(&compile)?),
         })
     }
 }

--- a/librashader-reflect/src/back/hlsl.rs
+++ b/librashader-reflect/src/back/hlsl.rs
@@ -1,10 +1,9 @@
 use crate::back::targets::HLSL;
-use crate::back::{CompileShader, CompilerBackend, FromCompilation};
+use crate::back::{CompileReflectShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::hlsl::HlslReflect;
 use crate::reflect::cross::{CompiledProgram, SpirvCross};
-use crate::reflect::ReflectShader;
 
 /// The HLSL shader model version to target.
 pub use spirv_cross2::compile::hlsl::HlslShaderModel;
@@ -108,8 +107,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     type Target = HLSL;
     type Options = Option<HlslShaderModel>;
     type Context = CrossHlslContext;
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/back/hlsl.rs
+++ b/librashader-reflect/src/back/hlsl.rs
@@ -46,7 +46,7 @@ impl HlslBufferAssignments {
         {
             return true;
         }
-        return false;
+        false
     }
 
     // Check if the mangled name matches.
@@ -91,7 +91,7 @@ impl HlslBufferAssignments {
             return true;
         }
 
-        return false;
+        false
     }
 }
 
@@ -103,6 +103,7 @@ pub struct CrossHlslContext {
     pub fragment_buffers: HlslBufferAssignments,
 }
 
+#[cfg(not(feature = "stable"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     type Target = HLSL;
     type Options = Option<HlslShaderModel>;
@@ -114,6 +115,22 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
             backend: HlslReflect::try_from(&compile)?,
+        })
+    }
+}
+
+#[cfg(feature = "stable")]
+impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
+    type Target = HLSL;
+    type Options = Option<HlslShaderModel>;
+    type Context = CrossHlslContext;
+    type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross> + Send>;
+
+    fn from_compilation(
+        compile: SpirvCompilation,
+    ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
+        Ok(CompilerBackend {
+            backend: Box::new(HlslReflect::try_from(&compile)?),
         })
     }
 }

--- a/librashader-reflect/src/back/msl.rs
+++ b/librashader-reflect/src/back/msl.rs
@@ -1,5 +1,5 @@
 use crate::back::targets::MSL;
-use crate::back::{CompileReflectShader, CompileShader, CompilerBackend, FromCompilation};
+use crate::back::{CompileReflectShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::msl::MslReflect;
@@ -29,8 +29,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
     type Context = CrossMslContext;
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/back/msl.rs
+++ b/librashader-reflect/src/back/msl.rs
@@ -5,7 +5,6 @@ use crate::front::SpirvCompilation;
 use crate::reflect::cross::msl::MslReflect;
 use crate::reflect::cross::{CompiledProgram, SpirvCross};
 use crate::reflect::naga::{Naga, NagaReflect};
-use crate::reflect::ReflectShader;
 use naga::back::msl::TranslationInfo;
 use naga::Module;
 
@@ -25,6 +24,7 @@ pub struct CrossMslContext {
     pub artifact: CompiledProgram<spirv_cross2::targets::Msl>,
 }
 
+#[cfg(not(feature = "stable"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
@@ -36,6 +36,22 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
             backend: MslReflect::try_from(&compile)?,
+        })
+    }
+}
+
+#[cfg(feature = "stable")]
+impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
+    type Target = MSL;
+    type Options = Option<self::MslVersion>;
+    type Context = CrossMslContext;
+    type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross> + Send>;
+
+    fn from_compilation(
+        compile: SpirvCompilation,
+    ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
+        Ok(CompilerBackend {
+            backend: Box::new(MslReflect::try_from(&compile)?),
         })
     }
 }
@@ -52,6 +68,7 @@ pub struct NagaMslContext {
     pub next_free_binding: u32,
 }
 
+#[cfg(not(feature = "stable"))]
 impl FromCompilation<SpirvCompilation, Naga> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
@@ -63,6 +80,22 @@ impl FromCompilation<SpirvCompilation, Naga> for MSL {
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
             backend: NagaReflect::try_from(&compile)?,
+        })
+    }
+}
+
+#[cfg(feature = "stable")]
+impl FromCompilation<SpirvCompilation, Naga> for MSL {
+    type Target = MSL;
+    type Options = Option<self::MslVersion>;
+    type Context = NagaMslContext;
+    type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, Naga> + Send>;
+
+    fn from_compilation(
+        compile: SpirvCompilation,
+    ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
+        Ok(CompilerBackend {
+            backend: Box::new(NagaReflect::try_from(&compile)?),
         })
     }
 }

--- a/librashader-reflect/src/back/msl.rs
+++ b/librashader-reflect/src/back/msl.rs
@@ -1,5 +1,5 @@
 use crate::back::targets::MSL;
-use crate::back::{CompileShader, CompilerBackend, FromCompilation};
+use crate::back::{CompileReflectShader, CompileShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::msl::MslReflect;
@@ -57,8 +57,7 @@ impl FromCompilation<SpirvCompilation, Naga> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
     type Context = NagaMslContext;
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, Naga>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/back/spirv.rs
+++ b/librashader-reflect/src/back/spirv.rs
@@ -63,6 +63,17 @@ impl CompileShader<SPIRV> for WriteSpirV {
             context: (),
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        _options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<Vec<u32>, Self::Context>, ShaderCompileError> {
+        Ok(ShaderCompilerOutput {
+            vertex: self.vertex,
+            fragment: self.fragment,
+            context: (),
+        })
+    }
 }
 
 /// The context for a SPIRV compilation via Naga

--- a/librashader-reflect/src/back/spirv.rs
+++ b/librashader-reflect/src/back/spirv.rs
@@ -1,5 +1,7 @@
 use crate::back::targets::SPIRV;
-use crate::back::{CompileShader, CompilerBackend, FromCompilation, ShaderCompilerOutput};
+use crate::back::{
+    CompileReflectShader, CompileShader, CompilerBackend, FromCompilation, ShaderCompilerOutput,
+};
 use crate::error::{ShaderCompileError, ShaderReflectError};
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::glsl::GlslReflect;
@@ -20,8 +22,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for SPIRV {
     type Target = SPIRV;
     type Options = Option<()>;
     type Context = ();
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross>;
 
     fn from_compilation(
         compile: SpirvCompilation,
@@ -86,8 +87,7 @@ impl FromCompilation<SpirvCompilation, Naga> for SPIRV {
     type Target = SPIRV;
     type Options = NagaSpirvOptions;
     type Context = NagaSpirvContext;
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, Naga>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/back/wgsl.rs
+++ b/librashader-reflect/src/back/wgsl.rs
@@ -11,6 +11,7 @@ pub struct NagaWgslContext {
     pub vertex: Module,
 }
 
+#[cfg(not(feature = "stable"))]
 impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     type Target = WGSL;
     type Options = NagaLoweringOptions;
@@ -22,6 +23,22 @@ impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
             backend: NagaReflect::try_from(&compile)?,
+        })
+    }
+}
+
+#[cfg(feature = "stable")]
+impl FromCompilation<SpirvCompilation, Naga> for WGSL {
+    type Target = WGSL;
+    type Options = NagaLoweringOptions;
+    type Context = NagaWgslContext;
+    type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, Naga> + Send>;
+
+    fn from_compilation(
+        compile: SpirvCompilation,
+    ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
+        Ok(CompilerBackend {
+            backend: Box::new(NagaReflect::try_from(&compile)?),
         })
     }
 }

--- a/librashader-reflect/src/back/wgsl.rs
+++ b/librashader-reflect/src/back/wgsl.rs
@@ -1,9 +1,8 @@
 use crate::back::targets::WGSL;
-use crate::back::{CompileShader, CompilerBackend, FromCompilation};
+use crate::back::{CompileReflectShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
 use crate::reflect::naga::{Naga, NagaLoweringOptions, NagaReflect};
-use crate::reflect::ReflectShader;
 use naga::Module;
 
 /// The context for a WGSL compilation via Naga
@@ -16,8 +15,7 @@ impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     type Target = WGSL;
     type Options = NagaLoweringOptions;
     type Context = NagaWgslContext;
-    type Output = impl CompileShader<Self::Target, Options = Self::Options, Context = Self::Context>
-        + ReflectShader;
+    type Output = impl CompileReflectShader<Self::Target, SpirvCompilation, Naga>;
 
     fn from_compilation(
         compile: SpirvCompilation,

--- a/librashader-reflect/src/lib.rs
+++ b/librashader-reflect/src/lib.rs
@@ -43,9 +43,9 @@
 //! librashader-reflect is designed to be compiler-agnostic. [naga](https://docs.rs/naga/latest/naga/index.html),
 //! a pure-Rust shader compiler, as well as SPIRV-Cross via [SpirvCompilation](crate::front::SpirvCompilation)
 //! is supported.
-#![feature(impl_trait_in_assoc_type)]
+#![cfg_attr(not(feature="stable"), feature(impl_trait_in_assoc_type))]
 #![allow(stable_features)]
-#![feature(c_str_literals)]
+#![cfg_attr(not(feature="stable"), feature(c_str_literals))]
 /// Shader codegen backends.
 pub mod back;
 /// Error types.

--- a/librashader-reflect/src/lib.rs
+++ b/librashader-reflect/src/lib.rs
@@ -43,9 +43,9 @@
 //! librashader-reflect is designed to be compiler-agnostic. [naga](https://docs.rs/naga/latest/naga/index.html),
 //! a pure-Rust shader compiler, as well as SPIRV-Cross via [SpirvCompilation](crate::front::SpirvCompilation)
 //! is supported.
-#![cfg_attr(not(feature="stable"), feature(impl_trait_in_assoc_type))]
+#![cfg_attr(not(feature = "stable"), feature(impl_trait_in_assoc_type))]
 #![allow(stable_features)]
-#![cfg_attr(not(feature="stable"), feature(c_str_literals))]
+#![cfg_attr(not(feature = "stable"), feature(c_str_literals))]
 /// Shader codegen backends.
 pub mod back;
 /// Error types.

--- a/librashader-reflect/src/reflect/cross/glsl.rs
+++ b/librashader-reflect/src/reflect/cross/glsl.rs
@@ -165,4 +165,11 @@ impl CompileShader<GLSL> for CrossReflect<targets::Glsl> {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <CrossReflect<targets::Glsl> as CompileShader<GLSL>>::compile(*self, options)
+    }
 }

--- a/librashader-reflect/src/reflect/cross/hlsl.rs
+++ b/librashader-reflect/src/reflect/cross/hlsl.rs
@@ -128,4 +128,11 @@ impl CompileShader<HLSL> for CrossReflect<targets::Hlsl> {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <CrossReflect<targets::Hlsl> as CompileShader<HLSL>>::compile(*self, options)
+    }
 }

--- a/librashader-reflect/src/reflect/cross/msl.rs
+++ b/librashader-reflect/src/reflect/cross/msl.rs
@@ -101,6 +101,13 @@ impl CompileShader<MSL> for CrossReflect<targets::Msl> {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <CrossReflect<targets::Msl> as CompileShader<MSL>>::compile(*self, options)
+    }
 }
 
 #[cfg(test)]

--- a/librashader-reflect/src/reflect/naga/msl.rs
+++ b/librashader-reflect/src/reflect/naga/msl.rs
@@ -146,6 +146,13 @@ impl CompileShader<MSL> for NagaReflect {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <NagaReflect as CompileShader<MSL>>::compile(*self, options)
+    }
 }
 
 #[cfg(test)]

--- a/librashader-reflect/src/reflect/naga/spirv.rs
+++ b/librashader-reflect/src/reflect/naga/spirv.rs
@@ -51,4 +51,11 @@ impl CompileShader<SPIRV> for NagaReflect {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<Vec<u32>, Self::Context>, ShaderCompileError> {
+        <NagaReflect as CompileShader<SPIRV>>::compile(*self, options)
+    }
 }

--- a/librashader-reflect/src/reflect/naga/wgsl.rs
+++ b/librashader-reflect/src/reflect/naga/wgsl.rs
@@ -38,4 +38,11 @@ impl CompileShader<WGSL> for NagaReflect {
             },
         })
     }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <NagaReflect as CompileShader<WGSL>>::compile(*self, options)
+    }
 }

--- a/librashader-runtime-d3d11/Cargo.toml
+++ b/librashader-runtime-d3d11/Cargo.toml
@@ -26,6 +26,7 @@ array-concat = "0.5.2"
 
 [features]
 debug-shader = []
+stable = ["librashader-reflect/stable"]
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/librashader-runtime-d3d11/src/filter_chain.rs
+++ b/librashader-runtime-d3d11/src/filter_chain.rs
@@ -73,8 +73,15 @@ pub(crate) struct FilterCommon {
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-d3d11/src/lib.rs
+++ b/librashader-runtime-d3d11/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::d3d11`](https://docs.rs/librashader/latest/librashader/runtime/d3d11/index.html) instead.
 
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod draw_quad;
 mod filter_chain;

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -33,6 +33,9 @@ gpu-allocator = { version = "0.27.0", features = ["d3d12"], default-features = f
 parking_lot = "0.12.3"
 d3d12-descriptor-heap = "0.1.0"
 
+[features]
+stable = ["librashader-reflect/stable"]
+
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true
 features = [

--- a/librashader-runtime-d3d12/src/filter_chain.rs
+++ b/librashader-runtime-d3d12/src/filter_chain.rs
@@ -169,8 +169,15 @@ impl Drop for FrameResiduals {
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type DxilShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<DXIL, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type DxilShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<DXIL, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes_dxil(
         shaders: Vec<ShaderPassConfig>,
@@ -192,8 +199,14 @@ mod compile {
         Ok((passes, semantics))
     }
 
+    #[cfg(not(feature = "stable"))]
     pub type HlslShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type HlslShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes_hlsl(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-d3d12/src/lib.rs
+++ b/librashader-runtime-d3d12/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 #![deny(unsafe_op_in_unsafe_fn)]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod buffer;
 mod descriptor_heap;

--- a/librashader-runtime-d3d9/Cargo.toml
+++ b/librashader-runtime-d3d9/Cargo.toml
@@ -26,6 +26,9 @@ num-traits = "0.2.18"
 
 windows-core = "0.58.0"
 
+[features]
+stable = ["librashader-reflect/stable"]
+
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true
 features = [

--- a/librashader-runtime-d3d9/src/filter_chain.rs
+++ b/librashader-runtime-d3d9/src/filter_chain.rs
@@ -60,8 +60,15 @@ pub struct FilterChainD3D9 {
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-d3d9/src/lib.rs
+++ b/librashader-runtime-d3d9/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(target_os = "windows")]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+
 mod binding;
 mod d3dx;
 mod draw_quad;

--- a/librashader-runtime-gl/Cargo.toml
+++ b/librashader-runtime-gl/Cargo.toml
@@ -27,6 +27,9 @@ rayon = "1.6.1"
 
 sptr = "0.3"
 
+[features]
+stable = ["librashader-reflect/stable"]
+
 [dev-dependencies]
 glfw = "0.47.0"
 

--- a/librashader-runtime-gl/src/filter_chain/filter_impl.rs
+++ b/librashader-runtime-gl/src/filter_chain/filter_impl.rs
@@ -89,8 +89,15 @@ impl<T: GLInterface> FilterChainImpl<T> {
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<GLSL, SpirvCompilation, SpirvCross>>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<GLSL, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-gl/src/lib.rs
+++ b/librashader-runtime-gl/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::gl`](https://docs.rs/librashader/latest/librashader/runtime/gl/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod binding;
 mod filter_chain;

--- a/librashader-runtime-mtl/Cargo.toml
+++ b/librashader-runtime-mtl/Cargo.toml
@@ -39,7 +39,7 @@ objc2-metal = { workspace = true, features = ["all"] }
 objc2 = { workspace = true, features = ["apple"] }
 
 [features]
-# run_test = ["icrate/AppKit", "i "icrate/Foundation_all", "icrate/MetalKit", "icrate/MetalKit_all"]
+stable = ["librashader-reflect/stable"]
 
 [target.'cfg(target_vendor="apple")'.dev-dependencies]
 objc2-metal-kit = { version = "0.2", features = ["all"]}

--- a/librashader-runtime-mtl/src/filter_chain.rs
+++ b/librashader-runtime-mtl/src/filter_chain.rs
@@ -41,8 +41,14 @@ use std::path::Path;
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<MSL, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta =
+        ShaderPassArtifact<Box<dyn CompileReflectShader<MSL, SpirvCompilation, SpirvCross> + Send>>;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-mtl/src/lib.rs
+++ b/librashader-runtime-mtl/src/lib.rs
@@ -1,5 +1,10 @@
+//! librashader Metal runtime
+//!
+//! This crate should not be used directly.
+//! See [`librashader::runtime::mtl`](https://docs.rs/librashader/latest/aarch64-apple-darwin/librashader/runtime/mtl/index.html) instead.
+
 #![cfg(target_vendor = "apple")]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod buffer;
 mod draw_quad;

--- a/librashader-runtime-vk/Cargo.toml
+++ b/librashader-runtime-vk/Cargo.toml
@@ -30,6 +30,9 @@ array-concat = "0.5.2"
 
 ash = { workspace = true, features = ["debug"] }
 
+[features]
+stable = ["librashader-reflect/stable"]
+
 [dev-dependencies]
 num = "0.4.0"
 glfw = "0.49.0"

--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -206,8 +206,15 @@ impl Drop for FrameResiduals {
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<SPIRV, SpirvCompilation, SpirvCross> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta = ShaderPassArtifact<
+        Box<dyn CompileReflectShader<SPIRV, SpirvCompilation, SpirvCross> + Send>,
+    >;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-vk/src/lib.rs
+++ b/librashader-runtime-vk/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::vk`](https://docs.rs/librashader/latest/librashader/runtime/vk/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod draw_quad;
 mod filter_chain;

--- a/librashader-runtime-wgpu/Cargo.toml
+++ b/librashader-runtime-wgpu/Cargo.toml
@@ -33,6 +33,8 @@ wgpu_dx12 = ["wgpu/dx12"]
 wgpu_metal = ["wgpu/metal"]
 wgpu_webgpu = ["wgpu/webgpu"]
 
+stable = ["librashader-reflect/stable"]
+
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 rayon = "1.8.1"
 

--- a/librashader-runtime-wgpu/Cargo.toml
+++ b/librashader-runtime-wgpu/Cargo.toml
@@ -22,7 +22,6 @@ librashader-runtime = { path = "../librashader-runtime" , version = "0.4.2" }
 librashader-cache = { path = "../librashader-cache", version = "0.4.2" }
 
 wgpu = { workspace = true, default-features = false, features = ["wgsl"] }
-image = "0.25.1"
 thiserror = "1.0.50"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 array-concat = "0.5.2"

--- a/librashader-runtime-wgpu/src/filter_chain.rs
+++ b/librashader-runtime-wgpu/src/filter_chain.rs
@@ -40,8 +40,14 @@ use crate::texture::{InputImage, OwnedImage};
 
 mod compile {
     use super::*;
+
+    #[cfg(not(feature = "stable"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<WGSL, SpirvCompilation, Naga> + Send>;
+
+    #[cfg(feature = "stable")]
+    pub type ShaderPassMeta =
+        ShaderPassArtifact<Box<dyn CompileReflectShader<WGSL, SpirvCompilation, Naga> + Send>>;
 
     pub fn compile_passes(
         shaders: Vec<ShaderPassConfig>,

--- a/librashader-runtime-wgpu/src/lib.rs
+++ b/librashader-runtime-wgpu/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::wgpu`](https://docs.rs/librashader/latest/librashader/runtime/wgpu/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![feature(type_alias_impl_trait)]
+#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
 
 mod buffer;
 mod draw_quad;

--- a/librashader-runtime/Cargo.toml
+++ b/librashader-runtime/Cargo.toml
@@ -22,7 +22,7 @@ array-concat = "0.5.2"
 arc-swap = "1.7.1"
 
 [dependencies.image]
-version = "0.25.1"
+version = "0.25.2"
 features = [
     "gif", "jpeg", "png",
     "tga", "pnm", "tiff",

--- a/librashader/Cargo.toml
+++ b/librashader/Cargo.toml
@@ -47,7 +47,15 @@ runtime = []
 reflect = []
 preprocess = []
 presets = []
-
+stable = [ "librashader-reflect/stable",
+           "librashader-runtime-d3d9?/stable",
+           "librashader-runtime-d3d11?/stable",
+           "librashader-runtime-d3d12?/stable",
+           "librashader-runtime-gl?/stable",
+           "librashader-runtime-vk?/stable",
+           "librashader-runtime-mtl?/stable",
+           "librashader-runtime-wgpu?/stable"
+]
 # runtimes
 
 runtime-gl = [ "runtime", "reflect-cross", "librashader-common/opengl", "librashader-runtime-gl" ]

--- a/librashader/src/lib.rs
+++ b/librashader/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(missing_docs)]
-#![feature(doc_cfg)]
+#![cfg_attr(feature = "docsrs", feature(doc_cfg))]
 //! RetroArch shader preset compiler and runtime.
 //!
 //! librashader provides convenient and safe access to RetroArch ['slang' shaders](https://github.com/libretro/slang-shaders).
@@ -53,7 +53,7 @@ pub use librashader_common::map::FastHashMap;
 pub use librashader_common::map::ShortString;
 
 #[cfg(feature = "presets")]
-#[doc(cfg(feature = "presets"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "presets")))]
 /// Parsing and usage of shader presets.
 ///
 /// This module contains facilities and types for parsing `.slangp` shader presets files.
@@ -87,7 +87,7 @@ pub mod presets {
 }
 
 #[cfg(feature = "preprocess")]
-#[doc(cfg(feature = "preprocess"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "preprocess")))]
 /// Loading and preprocessing of 'slang' shader source files.
 ///
 /// This module contains facilities and types for resolving `#include` directives in `.slang`
@@ -101,7 +101,7 @@ pub mod preprocess {
 }
 
 #[cfg(feature = "reflect")]
-#[doc(cfg(feature = "reflect"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "reflect")))]
 /// Shader reflection and cross-compilation.
 ///
 /// The `type_alias_impl_trait` nightly feature is required. You should choose your
@@ -171,7 +171,7 @@ pub mod reflect {
 
     /// Reflection via SPIRV-Cross.
     #[cfg(feature = "reflect-cross")]
-    #[doc(cfg(feature = "reflect-cross"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "reflect-cross")))]
     pub mod cross {
         pub use librashader_reflect::reflect::cross::SpirvCross;
 
@@ -198,7 +198,10 @@ pub mod reflect {
 
     /// DXIL reflection via spirv-to-dxil.
     #[cfg(all(target_os = "windows", feature = "reflect-dxil"))]
-    #[doc(cfg(all(target_os = "windows", feature = "reflect-dxil")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "reflect-dxil")))
+    )]
     pub mod dxil {
         /// The maximum shader model to use when compiling the DXIL blob.
         pub use librashader_reflect::back::dxil::ShaderModel;
@@ -209,7 +212,7 @@ pub mod reflect {
 
     /// Reflection via Naga
     #[cfg(feature = "reflect-naga")]
-    #[doc(cfg(feature = "reflect-naga"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "reflect-naga")))]
     pub mod naga {
         pub use librashader_reflect::back::wgsl::NagaWgslContext;
         pub use librashader_reflect::reflect::naga::Naga;
@@ -233,14 +236,14 @@ pub mod reflect {
 
 /// Shader runtimes to execute a filter chain on a GPU surface.
 #[cfg(feature = "runtime")]
-#[doc(cfg(feature = "runtime"))]
+#[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime")))]
 pub mod runtime {
     pub use librashader_common::{Size, Viewport};
     pub use librashader_runtime::parameters::FilterChainParameters;
     pub use librashader_runtime::parameters::RuntimeParameters;
 
     #[cfg(feature = "runtime-gl")]
-    #[doc(cfg(feature = "runtime-gl"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-gl")))]
     /// Shader runtime for OpenGL 3.3+.
     ///
     /// DSA support requires OpenGL 4.6.
@@ -256,7 +259,10 @@ pub mod runtime {
     }
 
     #[cfg(all(target_os = "windows", feature = "runtime-d3d11"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d11")))
+    )]
     /// Shader runtime for Direct3D 11.
     pub mod d3d11 {
         pub use librashader_runtime_d3d11::{
@@ -269,7 +275,10 @@ pub mod runtime {
     }
 
     #[cfg(all(target_os = "windows", feature = "runtime-d3d12"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d12")))
+    )]
     /// Shader runtime for Direct3D 12.
     pub mod d3d12 {
         pub use librashader_runtime_d3d12::{
@@ -282,7 +291,10 @@ pub mod runtime {
     }
 
     #[cfg(all(target_os = "windows", feature = "runtime-d3d9"))]
-    #[doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_os = "windows", feature = "runtime-d3d9")))
+    )]
     /// Shader runtime for Direct3D 9.
     pub mod d3d9 {
         pub use librashader_runtime_d3d9::{
@@ -295,7 +307,7 @@ pub mod runtime {
     }
 
     #[cfg(feature = "runtime-vk")]
-    #[doc(cfg(feature = "runtime-vk"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-vk")))]
     /// Shader runtime for Vulkan.
     pub mod vk {
         pub use librashader_runtime_vk::{
@@ -308,7 +320,10 @@ pub mod runtime {
     }
 
     #[cfg(all(target_vendor = "apple", feature = "runtime-metal"))]
-    #[doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))]
+    #[cfg_attr(
+        feature = "docsrs",
+        doc(cfg(all(target_vendor = "apple", feature = "runtime-metal")))
+    )]
     /// Shader runtime for Metal.
     pub mod mtl {
         pub use librashader_runtime_mtl::{
@@ -321,7 +336,7 @@ pub mod runtime {
     }
 
     #[cfg(feature = "runtime-wgpu")]
-    #[doc(cfg(feature = "runtime-wgpu"))]
+    #[cfg_attr(feature = "docsrs", doc(cfg(feature = "runtime-wgpu")))]
     /// Shader runtime for wgpu.
     pub mod wgpu {
         pub use librashader_runtime_wgpu::{


### PR DESCRIPTION
This allows building on stable Rust, but not without some caveats.

* C headers will not be regenerated when building with the `stable` feature.
* There is a minor performance hit in initial shader compilation when building against stable Rust. This is due to boxed trait objects being used instead of `impl Trait`.
* A higher MSRV is required when building against stable Rust.

