### PR TITLE
Don't draw PassFeedbackN if N is the final pass and not read.

### DIFF
--- a/librashader-runtime-d3d11/tests/triangle.rs
+++ b/librashader-runtime-d3d11/tests/triangle.rs
@@ -15,9 +15,9 @@ use librashader_runtime_d3d11::options::FilterChainOptionsD3D11;
 // const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-royale.slangp";
 
 // const FILTER_PATH: &str = "../test/slang-shaders/test/history.slangp";
-// const FILTER_PATH: &str = "../test/shaders_slang/test/feedback.slangp";
+const FILTER_PATH: &str = "../test/shaders_slang/test/feedback.slangp";
 
-const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-royale.slangp";
+// const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-geom-deluxe.slangp";
 const IMAGE_PATH: &str = "../triangle.png";
 #[test]
 fn triangle_d3d11_args() {

--- a/librashader-runtime/src/binding.rs
+++ b/librashader-runtime/src/binding.rs
@@ -348,6 +348,11 @@ where
     }
 }
 
+pub struct BindingRequirements {
+    pub(crate) required_history: usize,
+    pub(crate) uses_final_pass_as_feedback: bool,
+}
+
 /// Trait for objects that can be used to create a binding map.
 pub trait BindingUtil {
     /// Create the uniform binding map with the given reflection information.
@@ -357,7 +362,7 @@ pub trait BindingUtil {
     ) -> FastHashMap<UniformBinding, T>;
 
     /// Calculate the number of required images for history.
-    fn calculate_required_history<'a>(pass_meta: impl Iterator<Item = &'a Self>) -> usize
+    fn calculate_requirements<'a>(pass_meta: impl Iterator<Item = &'a Self>) -> BindingRequirements
     where
         Self: 'a;
 }
@@ -383,32 +388,65 @@ impl BindingUtil for BindingMeta {
         uniform_bindings
     }
 
-    fn calculate_required_history<'a>(pass_meta: impl Iterator<Item = &'a Self>) -> usize
+    fn calculate_requirements<'a>(pass_meta: impl Iterator<Item = &'a Self>) -> BindingRequirements
     where
         Self: 'a,
     {
         let mut required_images = 0;
 
+        let mut len: i64 = 0;
+        let mut latest_feedback_pass: i64 = -1;
+
         for pass in pass_meta {
+            len += 1;
+
             // If a shader uses history size, but not history, we still need to keep the texture.
-            let texture_max_index = pass
+            let history_texture_max_index = pass
                 .texture_meta
                 .iter()
                 .filter(|(semantics, _)| semantics.semantics == TextureSemantics::OriginalHistory)
                 .map(|(semantic, _)| semantic.index)
                 .fold(0, std::cmp::max);
-            let texture_size_max_index = pass
+            let history_texture_size_max_index = pass
                 .texture_size_meta
                 .iter()
                 .filter(|(semantics, _)| semantics.semantics == TextureSemantics::OriginalHistory)
                 .map(|(semantic, _)| semantic.index)
                 .fold(0, std::cmp::max);
 
-            required_images = std::cmp::max(required_images, texture_max_index);
-            required_images = std::cmp::max(required_images, texture_size_max_index);
+            let feedback_max_index = pass
+                .texture_meta
+                .iter()
+                .filter(|(semantics, _)| semantics.semantics == TextureSemantics::PassFeedback)
+                .map(|(semantic, _)| semantic.index as i64)
+                .fold(-1, std::cmp::max);
+            let feedback_max_size_index = pass
+                .texture_size_meta
+                .iter()
+                .filter(|(semantics, _)| semantics.semantics == TextureSemantics::PassFeedback)
+                .map(|(semantic, _)| semantic.index as i64)
+                .fold(-1, std::cmp::max);
+
+            latest_feedback_pass = std::cmp::max(latest_feedback_pass, feedback_max_index);
+            latest_feedback_pass = std::cmp::max(latest_feedback_pass, feedback_max_size_index);
+
+            required_images = std::cmp::max(required_images, history_texture_max_index);
+            required_images = std::cmp::max(required_images, history_texture_size_max_index);
         }
 
-        required_images
+        let uses_feedback = if latest_feedback_pass.is_negative() {
+            false
+        } else {
+            // Technically = but we can be permissive here
+
+            // account for off by 1
+            latest_feedback_pass + 1 >= len
+        };
+
+        BindingRequirements {
+            required_history: required_images,
+            uses_final_pass_as_feedback: uses_feedback,
+        }
     }
 }
 


### PR DESCRIPTION
#117 fixes the problem of PassFeedback0 being unwritten if it is last frame. However many shaders don't need to use PassFeedback at all, and drawing twice is not zero-cost unlike feedback for other frames which is just a mem swap.

This does some reflection to determine if the last feedback pass is ever read, and only to draw to the output_texture framebuffer if needed. This allows the final pass to be zero-cost again unless it's needed to be read.

Further optimizations could be applied narrowly to the case by adding an implicit blit pass so the final pass is only drawn once.