### PR TITLE
Preset and reflect fixes

### DIFF
--- a/librashader-preprocess/src/lib.rs
+++ b/librashader-preprocess/src/lib.rs
@@ -81,6 +81,7 @@ impl SourceOutput for String {
 pub(crate) fn load_shader_source(path: impl AsRef<Path>) -> Result<ShaderSource, PreprocessError> {
     let source = read_source(path)?;
     let meta = pragma::parse_pragma_meta(&source)?;
+
     let text = stage::process_stages(&source)?;
     let parameters = FastHashMap::from_iter(meta.parameters.into_iter().map(|p| (p.id.clone(), p)));
 

--- a/librashader-preprocess/src/pragma.rs
+++ b/librashader-preprocess/src/pragma.rs
@@ -110,12 +110,12 @@ pub(crate) fn parse_pragma_meta(source: impl AsRef<str>) -> Result<ShaderMeta, P
             }
         }
 
-        if line.starts_with("#pragma name ") {
+        if let Some(pragma_name) = line.strip_prefix("#pragma name ") {
             if name.is_some() {
                 return Err(PreprocessError::DuplicatePragmaError(line.into()));
             }
 
-            name = Some(ShortString::from(line.trim()))
+            name = Some(ShortString::from(pragma_name.trim()))
         }
     }
 

--- a/librashader-reflect/src/reflect/presets.rs
+++ b/librashader-reflect/src/reflect/presets.rs
@@ -105,9 +105,11 @@ where
         })
         .collect::<Result<Vec<(ShaderPassConfig, ShaderSource, CompilerBackend<_>)>, E>>()?;
 
-    for details in &passes {
-        insert_pass_semantics(&mut uniform_semantics, &mut texture_semantics, &details.0)
+    for (config, source, _) in &passes {
+        insert_pass_semantics(&mut uniform_semantics, &mut texture_semantics, config.alias.as_ref(), config.id as usize);
+        insert_pass_semantics(&mut uniform_semantics, &mut texture_semantics, source.name.as_ref(), config.id as usize);
     }
+
     insert_lut_semantics(textures, &mut uniform_semantics, &mut texture_semantics);
 
     let semantics = ShaderSemantics {
@@ -122,9 +124,10 @@ where
 fn insert_pass_semantics(
     uniform_semantics: &mut FastHashMap<ShortString, UniformSemantic>,
     texture_semantics: &mut FastHashMap<ShortString, Semantic<TextureSemantics>>,
-    config: &ShaderPassConfig,
+    alias: Option<&ShortString>,
+    index: usize,
 ) {
-    let Some(alias) = &config.alias else {
+    let Some(alias) = alias else {
         return;
     };
 
@@ -132,8 +135,6 @@ fn insert_pass_semantics(
     if alias.trim().is_empty() {
         return;
     }
-
-    let index = config.id as usize;
 
     // PassOutput
     texture_semantics.insert(

--- a/librashader-reflect/src/reflect/semantics.rs
+++ b/librashader-reflect/src/reflect/semantics.rs
@@ -249,7 +249,6 @@ impl MemberOffset {
 /// Reflection information about a non-texture related uniform variable.
 #[derive(Debug)]
 pub struct VariableMeta {
-    // this might bite us in the back because retroarch keeps separate UBO/push offsets.. eh
     /// The offset of this variable uniform.
     pub offset: MemberOffset,
     /// The size of the uniform.
@@ -424,7 +423,7 @@ impl UniqueSemanticMap for FastHashMap<ShortString, UniformSemantic> {
                     index: (),
                 }),
                 "CurrentSubFrame" => Some(Semantic {
-                    semantics: UniqueSemantics::TotalSubFrames,
+                    semantics: UniqueSemantics::CurrentSubFrame,
                     index: (),
                 }),
                 _ => None,


### PR DESCRIPTION
* Fix handling of `#pragma name`
* Fix `CurrentSubFrame` being parsed as `TotalSubFrames`, this would cause issues for shaders with UBOs that used both.