### PR TITLE
Bugfixes and improvements from testing harness experimentation

### DIFF
--- a/librashader-capi/src/runtime/d3d9/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d9/filter_chain.rs
@@ -7,6 +7,7 @@ use librashader::runtime::d3d9::{FilterChain, FilterChainOptions, FrameOptions};
 use std::ffi::c_char;
 use std::ffi::CStr;
 use std::mem::{ManuallyDrop, MaybeUninit};
+use std::ops::Deref;
 use std::ptr::NonNull;
 use std::slice;
 use windows::Win32::Graphics::Direct3D9::{IDirect3DDevice9, IDirect3DSurface9, IDirect3DTexture9};
@@ -179,7 +180,7 @@ extern_fn! {
 
 
         unsafe {
-            chain.frame(ManuallyDrop::into_inner(image.clone()), &viewport, frame_count, options.as_ref())?;
+            chain.frame(image.deref(), &viewport, frame_count, options.as_ref())?;
         }
     }
 }

--- a/librashader-runtime-d3d9/src/draw_quad.rs
+++ b/librashader-runtime-d3d9/src/draw_quad.rs
@@ -4,14 +4,15 @@ use array_concat::concat_arrays;
 use bytemuck::offset_of;
 use librashader_runtime::quad::{QuadType, VertexInput};
 
-use windows::Win32::Foundation::FALSE;
+use windows::Win32::Foundation::{FALSE, TRUE};
 
 use windows::Win32::Graphics::Direct3D9::{
     IDirect3DDevice9, IDirect3DVertexBuffer9, IDirect3DVertexDeclaration9, D3DCMP_ALWAYS,
     D3DCULL_NONE, D3DDECLMETHOD_DEFAULT, D3DDECLTYPE_FLOAT2, D3DDECLTYPE_FLOAT3,
     D3DDECLTYPE_UNUSED, D3DDECLUSAGE_TEXCOORD, D3DPOOL_DEFAULT, D3DPT_TRIANGLESTRIP,
-    D3DRS_CLIPPING, D3DRS_COLORWRITEENABLE, D3DRS_CULLMODE, D3DRS_LIGHTING, D3DRS_ZENABLE,
-    D3DRS_ZFUNC, D3DTRANSFORMSTATETYPE, D3DTS_PROJECTION, D3DTS_VIEW, D3DVERTEXELEMENT9,
+    D3DRS_ALPHABLENDENABLE, D3DRS_CLIPPING, D3DRS_COLORWRITEENABLE, D3DRS_CULLMODE, D3DRS_LIGHTING,
+    D3DRS_ZENABLE, D3DRS_ZFUNC, D3DTRANSFORMSTATETYPE, D3DTS_PROJECTION, D3DTS_VIEW,
+    D3DVERTEXELEMENT9,
 };
 
 const OFFSCREEN_VBO_DATA: [VertexInput; 4] = [
@@ -112,6 +113,7 @@ impl DrawQuad {
             device.SetRenderState(D3DRS_LIGHTING, FALSE.0 as u32)?;
 
             device.SetRenderState(D3DRS_COLORWRITEENABLE, 0xfu32)?;
+            device.SetRenderState(D3DRS_ALPHABLENDENABLE, FALSE.0 as u32)?;
             device.BeginScene()?;
             device.SetStreamSource(0, &self.vbo, 0, std::mem::size_of::<VertexInput>() as u32)?;
             // device.SetFVF(D3DFVF_XYZRHW | D3DFVF_TEX1)?;

--- a/librashader-runtime-d3d9/src/draw_quad.rs
+++ b/librashader-runtime-d3d9/src/draw_quad.rs
@@ -4,7 +4,7 @@ use array_concat::concat_arrays;
 use bytemuck::offset_of;
 use librashader_runtime::quad::{QuadType, VertexInput};
 
-use windows::Win32::Foundation::{FALSE, TRUE};
+use windows::Win32::Foundation::FALSE;
 
 use windows::Win32::Graphics::Direct3D9::{
     IDirect3DDevice9, IDirect3DVertexBuffer9, IDirect3DVertexDeclaration9, D3DCMP_ALWAYS,

--- a/librashader-runtime-d3d9/src/filter_chain.rs
+++ b/librashader-runtime-d3d9/src/filter_chain.rs
@@ -23,7 +23,7 @@ use librashader_reflect::reflect::semantics::ShaderSemantics;
 use librashader_reflect::reflect::ReflectShader;
 use librashader_runtime::binding::{BindingUtil, TextureInput};
 use librashader_runtime::framebuffer::FramebufferInit;
-use librashader_runtime::image::{Image, ImageError, UVDirection, ARGB8};
+use librashader_runtime::image::{Image, ImageError, UVDirection, ARGB8, BGRA8};
 use librashader_runtime::quad::QuadType;
 use librashader_runtime::render_target::RenderTarget;
 use librashader_runtime::scaling::ScaleFramebuffer;
@@ -190,7 +190,7 @@ impl FilterChainD3D9 {
         let images = textures
             .iter()
             .map(|texture| Image::load(&texture.path, UVDirection::TopLeft))
-            .collect::<Result<Vec<Image<ARGB8>>, ImageError>>()?;
+            .collect::<Result<Vec<Image<BGRA8>>, ImageError>>()?;
 
         for (index, (texture, image)) in textures.iter().zip(images).enumerate() {
             let texture = LutTexture::new(device, &image, &texture)?;

--- a/librashader-runtime-d3d9/src/filter_chain.rs
+++ b/librashader-runtime-d3d9/src/filter_chain.rs
@@ -23,7 +23,7 @@ use librashader_reflect::reflect::semantics::ShaderSemantics;
 use librashader_reflect::reflect::ReflectShader;
 use librashader_runtime::binding::{BindingUtil, TextureInput};
 use librashader_runtime::framebuffer::FramebufferInit;
-use librashader_runtime::image::{Image, ImageError, UVDirection, ARGB8, BGRA8};
+use librashader_runtime::image::{Image, ImageError, UVDirection, BGRA8};
 use librashader_runtime::quad::QuadType;
 use librashader_runtime::render_target::RenderTarget;
 use librashader_runtime::scaling::ScaleFramebuffer;
@@ -288,7 +288,7 @@ impl FilterChainD3D9 {
     ///   * `input` must be in `D3DPOOL_DEFAULT`.
     pub unsafe fn frame(
         &mut self,
-        input: IDirect3DTexture9,
+        input: &IDirect3DTexture9,
         viewport: &Viewport<IDirect3DSurface9>,
         frame_count: usize,
         options: Option<&FrameOptionsD3D9>,

--- a/librashader-runtime-d3d9/src/luts.rs
+++ b/librashader-runtime-d3d9/src/luts.rs
@@ -3,7 +3,7 @@ use crate::error::assume_d3d_init;
 use crate::texture::D3D9InputTexture;
 
 use librashader_presets::TextureConfig;
-use librashader_runtime::image::{Image, ARGB8, BGRA8};
+use librashader_runtime::image::{Image, BGRA8};
 
 use windows::Win32::Graphics::Direct3D9::{
     IDirect3DDevice9, D3DFMT_A8R8G8B8, D3DLOCKED_RECT, D3DPOOL_MANAGED,

--- a/librashader-runtime-d3d9/src/luts.rs
+++ b/librashader-runtime-d3d9/src/luts.rs
@@ -3,7 +3,7 @@ use crate::error::assume_d3d_init;
 use crate::texture::D3D9InputTexture;
 
 use librashader_presets::TextureConfig;
-use librashader_runtime::image::{Image, ARGB8};
+use librashader_runtime::image::{Image, ARGB8, BGRA8};
 
 use windows::Win32::Graphics::Direct3D9::{
     IDirect3DDevice9, D3DFMT_A8R8G8B8, D3DLOCKED_RECT, D3DPOOL_MANAGED,
@@ -21,7 +21,7 @@ impl AsRef<D3D9InputTexture> for LutTexture {
 impl LutTexture {
     pub fn new(
         device: &IDirect3DDevice9,
-        source: &Image<ARGB8>,
+        source: &Image<BGRA8>,
         config: &TextureConfig,
     ) -> error::Result<LutTexture> {
         let mut texture = None;

--- a/librashader-runtime-d3d9/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d9/tests/hello_triangle/mod.rs
@@ -195,10 +195,10 @@ pub mod d3d9_hello_triangle {
     use std::path::{Path, PathBuf};
 
     use librashader_common::{GetSize, Viewport};
-    use librashader_runtime::quad::IDENTITY_MVP;
     use librashader_runtime_d3d9::options::FilterChainOptionsD3D9;
     use librashader_runtime_d3d9::FilterChainD3D9;
     use std::time::Instant;
+    use librashader_runtime::image::{Image, UVDirection, ARGB8, BGRA8, RGBA8};
 
     pub struct Sample {
         pub direct3d: IDirect3D9,
@@ -230,6 +230,7 @@ pub mod d3d9_hello_triangle {
         // pub deferred_context: ID3D11DeviceContext,
         pub vbo: IDirect3DVertexBuffer9,
         pub vao: IDirect3DVertexDeclaration9,
+        pub texture: IDirect3DTexture9,
     }
 
     impl Sample {
@@ -284,6 +285,38 @@ pub mod d3d9_hello_triangle {
                 tex.unwrap()
             };
 
+            const IMAGE_PATH: &str = "../triangle.png";
+
+            let image = Image::<BGRA8>::load(IMAGE_PATH, UVDirection::TopLeft)
+                .expect("triangle.png not found");
+
+            let texture = unsafe {
+                let mut texture = None;
+                device.CreateTexture(
+                    image.size.width,
+                    image.size.height,
+                    1,
+                    0,
+                    D3DFMT_A8R8G8B8,
+                    D3DPOOL_MANAGED,
+                    &mut texture,
+                    std::ptr::null_mut(),
+                )?;
+
+                texture.unwrap()
+            };
+
+            unsafe {
+                let mut lock = D3DLOCKED_RECT::default();
+                texture.LockRect(0, &mut lock, std::ptr::null_mut(), 0)?;
+                std::ptr::copy_nonoverlapping(
+                    image.bytes.as_ptr(),
+                    lock.pBits.cast(),
+                    image.bytes.len(),
+                );
+                texture.UnlockRect(0)?;
+            }
+
             self.resources = Some(Resources {
                 device,
                 filter,
@@ -292,18 +325,7 @@ pub mod d3d9_hello_triangle {
                 frame_end: Instant::now(),
                 frame_start: Instant::now(),
                 elapsed: 0f32,
-                // renderbuffer,
-                // renderbufffer_rtv: render_rtv,
-                // deferred_context: context,
-                // viewport: D3D11_VIEWPORT {
-                //     TopLeftX: 0.0,
-                //     TopLeftY: 0.0,
-                //     Width: WIDTH as f32,
-                //     Height: HEIGHT as f32,
-                //     MinDepth: D3D11_MIN_DEPTH,
-                //     MaxDepth: D3D11_MAX_DEPTH,
-                // },
-                // shader_output: None,
+                texture,
                 frame_count: 0usize,
                 renderbuffer,
             });
@@ -348,68 +370,68 @@ pub mod d3d9_hello_triangle {
 
             // resources.triangle_uniform_values.model_matrix = Mat4::rotate(Quaternion::axis_angle(Vec3::new(0.0, 0.0, 1.0), resources.elapsed));
             unsafe {
-                resources
-                    .device
-                    .SetTransform(D3DTS_PROJECTION, IDENTITY_MVP.as_ptr().cast())?;
-                resources
-                    .device
-                    .SetTransform(D3DTS_VIEW, IDENTITY_MVP.as_ptr().cast())?;
-                resources
-                    .device
-                    .SetTransform(D3DTRANSFORMSTATETYPE(256), IDENTITY_MVP.as_ptr().cast())?;
-
-                let rendertarget = resources.renderbuffer.GetSurfaceLevel(0).unwrap();
-
+                // resources
+                //     .device
+                //     .SetTransform(D3DTS_PROJECTION, IDENTITY_MVP.as_ptr().cast())?;
+                // resources
+                //     .device
+                //     .SetTransform(D3DTS_VIEW, IDENTITY_MVP.as_ptr().cast())?;
+                // resources
+                //     .device
+                //     .SetTransform(D3DTRANSFORMSTATETYPE(256), IDENTITY_MVP.as_ptr().cast())?;
+                //
+                // let rendertarget = resources.renderbuffer.GetSurfaceLevel(0).unwrap();
+                //
                 let backbuffer = resources
                     .device
                     .GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO)?;
+                //
+                // resources.device.SetRenderTarget(0, &rendertarget)?;
 
-                resources.device.SetRenderTarget(0, &rendertarget)?;
+                // resources.device.Clear(
+                //     0,
+                //     std::ptr::null_mut(),
+                //     D3DCLEAR_TARGET as u32,
+                //     0xFF4d6699,
+                //     0.0,
+                //     0,
+                // )?;
 
-                resources.device.Clear(
-                    0,
-                    std::ptr::null_mut(),
-                    D3DCLEAR_TARGET as u32,
-                    0xFF4d6699,
-                    0.0,
-                    0,
-                )?;
-
-                resources.device.BeginScene()?;
-
-                resources.device.SetStreamSource(
-                    0,
-                    &resources.vbo,
-                    0,
-                    std::mem::size_of::<Vertex>() as u32,
-                )?;
-                resources.device.SetVertexDeclaration(&resources.vao)?;
-
-                resources
-                    .device
-                    .SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE.0 as u32)?;
-                resources
-                    .device
-                    .SetRenderState(D3DRS_CLIPPING, FALSE.0 as u32)?;
-                resources
-                    .device
-                    .SetRenderState(D3DRS_ZFUNC, D3DCMP_ALWAYS.0 as u32)?;
-
-                resources
-                    .device
-                    .SetRenderState(D3DRS_ZENABLE, FALSE.0 as u32)?;
-                resources
-                    .device
-                    .SetRenderState(D3DRS_LIGHTING, FALSE.0 as u32)?;
-
-                resources.device.DrawPrimitive(D3DPT_TRIANGLELIST, 0, 1)?;
-
-                resources.device.EndScene()?;
+                // resources.device.BeginScene()?;
+                //
+                // resources.device.SetStreamSource(
+                //     0,
+                //     &resources.vbo,
+                //     0,
+                //     std::mem::size_of::<Vertex>() as u32,
+                // )?;
+                // resources.device.SetVertexDeclaration(&resources.vao)?;
+                //
+                // resources
+                //     .device
+                //     .SetRenderState(D3DRS_CULLMODE, D3DCULL_NONE.0 as u32)?;
+                // resources
+                //     .device
+                //     .SetRenderState(D3DRS_CLIPPING, FALSE.0 as u32)?;
+                // resources
+                //     .device
+                //     .SetRenderState(D3DRS_ZFUNC, D3DCMP_ALWAYS.0 as u32)?;
+                //
+                // resources
+                //     .device
+                //     .SetRenderState(D3DRS_ZENABLE, FALSE.0 as u32)?;
+                // resources
+                //     .device
+                //     .SetRenderState(D3DRS_LIGHTING, FALSE.0 as u32)?;
+                //
+                // resources.device.DrawPrimitive(D3DPT_TRIANGLELIST, 0, 1)?;
+                //
+                // resources.device.EndScene()?;
 
                 resources
                     .filter
                     .frame(
-                        resources.renderbuffer.clone(),
+                        resources.texture.clone(),
                         &Viewport {
                             x: 0.0,
                             y: 0.0,

--- a/librashader-runtime-gl/src/error.rs
+++ b/librashader-runtime-gl/src/error.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum FilterChainError {
-    #[error("fbo initialization error")]
+    #[error("fbo initialization error {0:x}")]
     FramebufferInit(u32),
     #[error("SPIRV reflection error")]
     SpirvCrossReflectError(#[from] spirv_cross2::SpirvCrossError),

--- a/librashader-runtime-gl/src/filter_chain/chain.rs
+++ b/librashader-runtime-gl/src/filter_chain/chain.rs
@@ -377,7 +377,7 @@ impl<T: GLInterface> FilterChainImpl<T> {
                 &original,
                 &source,
                 RenderTarget::identity(target)?,
-            );
+            )?;
 
             let target = target.as_texture(pass.config.filter, pass.config.wrap_mode);
             self.common.output_textures[index] = target;
@@ -409,7 +409,7 @@ impl<T: GLInterface> FilterChainImpl<T> {
                     &original,
                     &source,
                     RenderTarget::viewport_with_output(target, viewport),
-                );
+                )?;
             }
 
             pass.draw(
@@ -421,7 +421,7 @@ impl<T: GLInterface> FilterChainImpl<T> {
                 &original,
                 &source,
                 RenderTarget::viewport_with_output(final_viewport, viewport),
-            );
+            )?;
             self.common.output_textures[passes_len - 1] = viewport
                 .output
                 .as_texture(pass.config.filter, pass.config.wrap_mode);

--- a/librashader-runtime-gl/src/filter_pass.rs
+++ b/librashader-runtime-gl/src/filter_pass.rs
@@ -15,7 +15,7 @@ use crate::filter_chain::FilterCommon;
 use crate::gl::{BindTexture, GLFramebuffer, GLInterface, UboRing};
 use crate::options::FrameOptionsGL;
 use crate::samplers::SamplerSet;
-use crate::GLImage;
+use crate::{error, GLImage};
 
 use crate::texture::InputTexture;
 
@@ -86,7 +86,7 @@ impl<T: GLInterface> FilterPass<T> {
         original: &InputTexture,
         source: &InputTexture,
         output: RenderTarget<GLFramebuffer, i32>,
-    ) {
+    ) -> error::Result<()> {
         let framebuffer = output.output;
 
         if self.config.mipmap_input && !parent.disable_mipmaps {
@@ -94,9 +94,7 @@ impl<T: GLInterface> FilterPass<T> {
         }
 
         unsafe {
-            parent
-                .context
-                .bind_framebuffer(glow::FRAMEBUFFER, Some(framebuffer.fbo));
+            framebuffer.bind::<T::FramebufferInterface>()?;
             parent.context.use_program(Some(self.program));
         }
 
@@ -154,6 +152,8 @@ impl<T: GLInterface> FilterPass<T> {
             parent.context.disable(glow::FRAMEBUFFER_SRGB);
             parent.context.bind_framebuffer(glow::FRAMEBUFFER, None);
         }
+
+        Ok(())
     }
 }
 

--- a/librashader-runtime-gl/src/gl/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/framebuffer.rs
@@ -87,6 +87,10 @@ impl GLFramebuffer {
             wrap_mode,
         }
     }
+
+    pub(crate) fn bind<T: FramebufferInterface>(&self) -> Result<()> {
+        T::bind(self)
+    }
 }
 
 /// A state-checked wrapper around a raw framebuffer, used exclusively for output images.

--- a/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
@@ -290,4 +290,23 @@ impl FramebufferInterface for Gl3Framebuffer {
 
         Ok(())
     }
+
+    fn bind(fb: &GLFramebuffer) -> Result<()> {
+        unsafe {
+            fb.ctx.bind_framebuffer(glow::FRAMEBUFFER, Some(fb.fbo));
+            fb.ctx.framebuffer_texture_2d(
+                glow::FRAMEBUFFER,
+                glow::COLOR_ATTACHMENT0,
+                glow::TEXTURE_2D,
+                fb.image,
+                0,
+            );
+            let status = fb.ctx.check_framebuffer_status(glow::FRAMEBUFFER);
+            if status != glow::FRAMEBUFFER_COMPLETE {
+                return Err(FilterChainError::FramebufferInit(status));
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
@@ -236,4 +236,16 @@ impl FramebufferInterface for Gl46Framebuffer {
         }
         Ok(())
     }
+
+    fn bind(fb: &GLFramebuffer) -> Result<()> {
+        unsafe {
+            fb.ctx.bind_framebuffer(glow::FRAMEBUFFER, Some(fb.fbo));
+            let status = fb.ctx.check_framebuffer_status(glow::FRAMEBUFFER);
+            if status != glow::FRAMEBUFFER_COMPLETE {
+                return Err(FilterChainError::FramebufferInit(status));
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/librashader-runtime-gl/src/gl/mod.rs
+++ b/librashader-runtime-gl/src/gl/mod.rs
@@ -120,7 +120,11 @@ pub(crate) trait FramebufferInterface {
 
         let size = source_size.scale_viewport(scaling, *viewport_size, *original_size);
 
-        if fb.size != size || (mipmap && fb.max_levels == 1) || (!mipmap && fb.max_levels != 1) {
+        if fb.size != size
+            || (mipmap && fb.max_levels == 1)
+            || (!mipmap && fb.max_levels != 1)
+            || fb.image.is_none()
+        {
             fb.size = size;
 
             if mipmap {
@@ -145,6 +149,7 @@ pub(crate) trait FramebufferInterface {
     fn clear<const REBIND: bool>(fb: &GLFramebuffer);
     fn copy_from(fb: &mut GLFramebuffer, image: &GLImage) -> Result<()>;
     fn init(fb: &mut GLFramebuffer, size: Size<u32>, format: impl Into<u32>) -> Result<()>;
+    fn bind(fb: &GLFramebuffer) -> Result<()>;
 }
 
 pub(crate) trait BindTexture {

--- a/librashader-runtime-gl/tests/hello_triangle/gl3.rs
+++ b/librashader-runtime-gl/tests/hello_triangle/gl3.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 
-use glfw::{Context, Glfw, Window, WindowEvent};
+use glfw::{fail_on_errors, Context, Glfw, GlfwReceiver, PWindow, Window, WindowEvent};
 
 use glow::HasContext;
 use librashader_common::{GetSize, Size, Viewport};
@@ -14,13 +14,13 @@ const TITLE: &str = "librashader OpenGL 3.3";
 
 pub fn setup() -> (
     Glfw,
-    Window,
-    Receiver<(f64, WindowEvent)>,
+    PWindow,
+    GlfwReceiver<(f64, WindowEvent)>,
     glow::Program,
     glow::VertexArray,
     Arc<glow::Context>,
 ) {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+    let mut glfw = glfw::init(fail_on_errors!()).unwrap();
     glfw.window_hint(glfw::WindowHint::ContextVersion(3, 3));
     glfw.window_hint(glfw::WindowHint::OpenGlProfile(
         glfw::OpenGlProfileHint::Core,
@@ -171,8 +171,8 @@ void main()
 pub fn do_loop(
     gl: &Arc<glow::Context>,
     mut glfw: Glfw,
-    mut window: Window,
-    events: Receiver<(f64, WindowEvent)>,
+    mut window: PWindow,
+    events: GlfwReceiver<(f64, WindowEvent)>,
     triangle_program: glow::Program,
     triangle_vao: glow::VertexArray,
     filter: &mut FilterChainGL,
@@ -183,7 +183,7 @@ pub fn do_loop(
     let quad_vbuf;
 
     let output_texture;
-    let output_framebuffer_handle;
+    // let output_framebuffer_handle;
     let output_quad_vbuf;
 
     unsafe {
@@ -270,10 +270,11 @@ pub fn do_loop(
     }
 
     unsafe {
+        gl.bind_framebuffer(glow::FRAMEBUFFER, None);
         // do frmaebuffer
-        output_framebuffer_handle = gl.create_framebuffer().unwrap();
-
-        gl.bind_framebuffer(glow::FRAMEBUFFER, Some(output_framebuffer_handle));
+        // output_framebuffer_handle = gl.create_framebuffer().unwrap();
+        //
+        // gl.bind_framebuffer(glow::FRAMEBUFFER, Some(output_framebuffer_handle));
 
         // glow::ObjectLabel(
         //     glow::FRAMEBUFFER,
@@ -324,18 +325,18 @@ pub fn do_loop(
         );
 
         // set color attachment
-        gl.framebuffer_texture_2d(
-            glow::FRAMEBUFFER,
-            glow::COLOR_ATTACHMENT0,
-            glow::TEXTURE_2D,
-            Some(output_texture),
-            0,
-        );
+        // gl.framebuffer_texture_2d(
+        //     glow::FRAMEBUFFER,
+        //     glow::COLOR_ATTACHMENT0,
+        //     glow::TEXTURE_2D,
+        //     Some(output_texture),
+        //     0,
+        // );
 
-        gl.draw_buffer(glow::COLOR_ATTACHMENT0);
-        if gl.check_framebuffer_status(glow::FRAMEBUFFER) != glow::FRAMEBUFFER_COMPLETE {
-            panic!("failed to create fbo")
-        }
+        // gl.draw_buffer(glow::COLOR_ATTACHMENT0);
+        // if gl.check_framebuffer_status(glow::FRAMEBUFFER) != glow::FRAMEBUFFER_COMPLETE {
+        //     panic!("failed to create fbo")
+        // }
 
         let fullscreen_fbo = [
             -1.0f32, -1.0, 0.0, 1.0, -1.0, 0.0, -1.0, 1.0, 0.0, -1.0, 1.0, 0.0, 1.0, -1.0, 0.0,

--- a/librashader-runtime-gl/tests/hello_triangle/gl46.rs
+++ b/librashader-runtime-gl/tests/hello_triangle/gl46.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 
-use glfw::{Context, Glfw, Window, WindowEvent};
+use glfw::{fail_on_errors, Context, Glfw, GlfwReceiver, PWindow, Window, WindowEvent};
 
 use glow::HasContext;
 use librashader_common::{GetSize, Size, Viewport};
@@ -14,13 +14,13 @@ const TITLE: &str = "librashader OpenGL 4.6";
 
 pub fn setup() -> (
     Glfw,
-    Window,
-    Receiver<(f64, WindowEvent)>,
+    PWindow,
+    GlfwReceiver<(f64, WindowEvent)>,
     glow::Program,
     glow::VertexArray,
     Arc<glow::Context>,
 ) {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+    let mut glfw = glfw::init(fail_on_errors!()).unwrap();
     glfw.window_hint(glfw::WindowHint::ContextVersion(4, 6));
     glfw.window_hint(glfw::WindowHint::OpenGlProfile(
         glfw::OpenGlProfileHint::Core,
@@ -155,8 +155,8 @@ void main()
 pub fn do_loop(
     gl: &Arc<glow::Context>,
     mut glfw: Glfw,
-    mut window: Window,
-    events: Receiver<(f64, WindowEvent)>,
+    mut window: PWindow,
+    events: GlfwReceiver<(f64, WindowEvent)>,
     triangle_program: glow::Program,
     triangle_vao: glow::VertexArray,
     filter: &mut FilterChainGL,

--- a/librashader-runtime-gl/tests/triangle.rs
+++ b/librashader-runtime-gl/tests/triangle.rs
@@ -11,17 +11,17 @@ fn triangle_gl() {
     unsafe {
         let mut filter = FilterChainGL::load_from_path(
             // "../test/basic.slangp",
-            "../test/shaders_slang/test/feedback.slangp",
+            "../test/shaders_slang/crt/crt-royale.slangp",
             Arc::clone(&context),
             Some(&FilterChainOptionsGL {
                 glsl_version: 0,
                 use_dsa: false,
                 force_no_mipmaps: false,
-                disable_cache: false,
+                disable_cache: true,
             }),
         )
         // FilterChain::load_from_path("../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp", None)
-        .unwrap();
+        .expect("Failed to load filter chain");
         hello_triangle::gl3::do_loop(&context, glfw, window, events, shader, vao, &mut filter);
     }
 }
@@ -35,7 +35,7 @@ fn triangle_gl46() {
             // "../test/slang-shaders/test/history.slangp",
             // "../test/basic.slangp",
             // "../test/shaders_slang/crt/crt-royale.slangp",
-            "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
+            "../test/shaders_slang/crt/crt-royale.slangp",
             Arc::clone(&context),
             Some(&FilterChainOptionsGL {
                 glsl_version: 330,


### PR DESCRIPTION
Add some small bugfixes to work around edge cases exposed by #109 

* gl: always ensure framebuffers are bound
* d3d9: disable alpha blending
* d3d9: load LUTS as BGRA8 instead of ARGB8
* d3d9: accept input image by ref to avoid clone