### PR TITLE
cli(render): allow specifying output dimensions

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -9,11 +9,12 @@ Commands:
   render      Render a shader preset against an image
   compare     Compare two runtimes and get a similarity score between the two runtimes rendering the same frame
   parse       Parse a preset and get a JSON representation of the data
+  pack        Create a serialized preset pack from a shader preset
   preprocess  Get the raw GLSL output of a preprocessed shader
   transpile   Transpile a shader in a given preset to the given format
   reflect     Reflect the shader relative to a preset, giving information about semantics used in a slang shader
   help        Print this message or the help of the given subcommand(s)
-
+    
 Options:
   -h, --help     Print help
   -V, --version  Print version
@@ -52,6 +53,11 @@ Options:
           The renderer will run up to the number of frames specified here to ensure feedback and history.
 
           [default: 0]
+          
+  -d, --dimensions <DIMENSIONS>
+          The dimensions of the image.
+
+          This is given in either explicit dimensions `WIDTHxHEIGHT`, or a percentage of the input image in `SCALE%`.
 
       --params <PARAMS>...
           Parameters to pass to the shader preset, comma separated with equals signs.
@@ -136,6 +142,11 @@ Options:
           The renderer will run up to the number of frames specified here to ensure feedback and history.
 
           [default: 0]
+          
+  -d, --dimensions <DIMENSIONS>
+          The dimensions of the image.
+
+          This is given in either explicit dimensions `WIDTHxHEIGHT`, or a percentage of the input image in `SCALE%`.
 
       --params <PARAMS>...
           Parameters to pass to the shader preset, comma separated with equals signs.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Commands:
   render      Render a shader preset against an image
   compare     Compare two runtimes and get a similarity score between the two runtimes rendering the same frame
   parse       Parse a preset and get a JSON representation of the data
+  pack        Create a serialized preset pack from a shader preset
   preprocess  Get the raw GLSL output of a preprocessed shader
   transpile   Transpile a shader in a given preset to the given format
   reflect     Reflect the shader relative to a preset, giving information about semantics used in a slang shader

--- a/librashader-capi/src/ctypes.rs
+++ b/librashader-capi/src/ctypes.rs
@@ -49,7 +49,7 @@ pub enum LIBRA_PRESET_CTX_RUNTIME {
     /// Metal
     Metal,
     /// Direct3D 9
-    D3D9_HLSL
+    D3D9_HLSL,
 }
 
 impl From<LIBRA_PRESET_CTX_RUNTIME> for VideoDriver {
@@ -61,7 +61,7 @@ impl From<LIBRA_PRESET_CTX_RUNTIME> for VideoDriver {
             LIBRA_PRESET_CTX_RUNTIME::D3D11 => VideoDriver::Direct3D11,
             LIBRA_PRESET_CTX_RUNTIME::D3D12 => VideoDriver::Direct3D12,
             LIBRA_PRESET_CTX_RUNTIME::Metal => VideoDriver::Metal,
-            LIBRA_PRESET_CTX_RUNTIME::D3D9_HLSL => VideoDriver::Direct3D9Hlsl
+            LIBRA_PRESET_CTX_RUNTIME::D3D9_HLSL => VideoDriver::Direct3D9Hlsl,
         }
     }
 }

--- a/librashader-cli/src/cli/main.rs
+++ b/librashader-cli/src/cli/main.rs
@@ -7,6 +7,7 @@ use librashader::reflect::cross::{GlslVersion, HlslShaderModel, MslVersion, Spir
 use librashader::reflect::naga::{Naga, NagaLoweringOptions};
 use librashader::reflect::semantics::ShaderSemantics;
 use librashader::reflect::{CompileShader, FromCompilation, ReflectShader, SpirvCompilation};
+use librashader::runtime::Size;
 use librashader::{FastHashMap, ShortString};
 use librashader_runtime::parameters::RuntimeParameters;
 use librashader_test::render::{CommonFrameOptions, RenderTest};
@@ -43,6 +44,12 @@ struct RenderArgs {
     /// to ensure feedback and history.
     #[arg(short, long, default_value_t = 0)]
     frame: usize,
+    /// The dimensions of the image.
+    ///
+    /// This is given in either explicit dimensions `WIDTHxHEIGHT`, or a
+    /// percentage of the input image in `SCALE%`.
+    #[arg(short, long)]
+    dimensions: Option<String>,
     /// Parameters to pass to the shader preset, comma separated with equals signs.
     ///
     /// For example, crt_gamma=2.5,halation_weight=0.001
@@ -313,6 +320,7 @@ pub fn main() -> Result<(), anyhow::Error> {
             let PresetArgs { preset, wildcards } = preset;
             let RenderArgs {
                 frame,
+                dimensions,
                 params,
                 passes_enabled,
                 image,
@@ -320,13 +328,14 @@ pub fn main() -> Result<(), anyhow::Error> {
             } = render;
 
             let test: &mut dyn RenderTest = get_runtime!(runtime, image);
-
+            let dimensions = parse_dimension(dimensions, test.image_size())?;
             let preset = get_shader_preset(preset, wildcards)?;
             let params = parse_params(params)?;
 
             let image = test.render_with_preset_and_params(
                 preset,
                 frame,
+                Some(dimensions),
                 Some(&|rp| set_params(rp, &params, passes_enabled)),
                 options.map(CommonFrameOptions::from),
             )?;
@@ -348,6 +357,7 @@ pub fn main() -> Result<(), anyhow::Error> {
             let PresetArgs { preset, wildcards } = preset;
             let RenderArgs {
                 frame,
+                dimensions,
                 params,
                 passes_enabled,
                 image,
@@ -357,12 +367,14 @@ pub fn main() -> Result<(), anyhow::Error> {
             let left: &mut dyn RenderTest = get_runtime!(left, image);
             let right: &mut dyn RenderTest = get_runtime!(right, image);
 
+            let dimensions = parse_dimension(dimensions, left.image_size())?;
             let params = parse_params(params)?;
 
             let left_preset = get_shader_preset(preset.clone(), wildcards.clone())?;
             let left_image = left.render_with_preset_and_params(
                 left_preset,
                 frame,
+                Some(dimensions),
                 Some(&|rp| set_params(rp, &params, passes_enabled)),
                 None,
             )?;
@@ -371,6 +383,7 @@ pub fn main() -> Result<(), anyhow::Error> {
             let right_image = right.render_with_preset_and_params(
                 right_preset,
                 frame,
+                Some(dimensions),
                 Some(&|rp| set_params(rp, &params, passes_enabled)),
                 options.map(CommonFrameOptions::from),
             )?;
@@ -741,4 +754,48 @@ fn parse_msl_version(version_str: &str) -> anyhow::Result<MslVersion> {
         }
         _ => return Err(anyhow!("Unknown MSL version")),
     })
+}
+
+fn parse_dimension(dimstr: Option<String>, image_dim: Size<u32>) -> anyhow::Result<Size<u32>> {
+    let Some(dimstr) = dimstr else {
+        return Ok(image_dim);
+    };
+
+    if dimstr.contains("x") {
+        if let Some((Ok(width), Ok(height))) = dimstr
+            .split_once("x")
+            .map(|(width, height)| (width.parse::<u32>(), height.parse::<u32>()))
+        {
+            if width < 1 || height < 1 {
+                return Err(anyhow!("Dimensions must be larger than 1x1"));
+            }
+
+            if width > 16384 || height > 16384 {
+                return Err(anyhow!("Dimensions must not be larger than 16384x16384"));
+            }
+            return Ok(Size::new(width, height));
+        }
+    }
+
+    if dimstr.ends_with("%") && dimstr.len() > 1 {
+        if let Ok(percent) = dimstr.trim_end_matches("%").parse::<u32>() {
+            let percent = percent as f32 / 100f32;
+            let width = (image_dim.width as f32 * percent) as u32;
+            let height = (image_dim.height as f32 * percent) as u32;
+
+            if width < 1 || height < 1 {
+                return Err(anyhow!("Dimensions must be larger than 1x1"));
+            }
+
+            if width > 16384 || height > 16384 {
+                return Err(anyhow!("Dimensions must not be larger than 16384x16384"));
+            }
+
+            return Ok(Size { width, height });
+        }
+    }
+
+    Err(anyhow!(
+        "Invalid dimension syntax, must either in form WIDTHxHEIGHT or SCALE%"
+    ))
 }

--- a/librashader-cli/src/render/mod.rs
+++ b/librashader-cli/src/render/mod.rs
@@ -20,6 +20,7 @@ pub mod wgpu;
 pub mod mtl;
 
 use librashader::presets::ShaderPreset;
+use librashader::runtime::Size;
 use librashader_runtime::impl_default_frame_options;
 use librashader_runtime::parameters::RuntimeParameters;
 use std::path::Path;
@@ -31,6 +32,9 @@ pub trait RenderTest {
     where
         Self: Sized;
 
+    /// Get the size of the image loaded.
+    fn image_size(&self) -> Size<u32>;
+
     /// Render a shader onto an image buffer, applying the provided shader.
     ///
     /// The test should render in linear colour space for proper comparison against
@@ -39,9 +43,14 @@ pub trait RenderTest {
     /// For testing purposes, it is often that a single image will be reused with multiple
     /// shader presets, so the actual image that a shader will be applied to
     /// will often be part of the test harness object.
-    fn render(&mut self, path: &Path, frame_count: usize) -> anyhow::Result<image::RgbaImage> {
+    fn render(
+        &mut self,
+        path: &Path,
+        frame_count: usize,
+        output_size: Option<Size<u32>>,
+    ) -> anyhow::Result<image::RgbaImage> {
         let preset = ShaderPreset::try_parse(path)?;
-        self.render_with_preset(preset, frame_count)
+        self.render_with_preset(preset, frame_count, output_size)
     }
 
     /// Render a shader onto an image buffer, applying the provided shader.
@@ -56,8 +65,9 @@ pub trait RenderTest {
         &mut self,
         preset: ShaderPreset,
         frame_count: usize,
+        output_size: Option<Size<u32>>,
     ) -> anyhow::Result<image::RgbaImage> {
-        self.render_with_preset_and_params(preset, frame_count, None, None)
+        self.render_with_preset_and_params(preset, frame_count, output_size, None, None)
     }
 
     /// Render a shader onto an image buffer, applying the provided shader.
@@ -72,6 +82,7 @@ pub trait RenderTest {
         &mut self,
         preset: ShaderPreset,
         frame_count: usize,
+        output_size: Option<Size<u32>>,
         param_setter: Option<&dyn Fn(&RuntimeParameters)>,
         frame_options: Option<CommonFrameOptions>,
     ) -> anyhow::Result<image::RgbaImage>;

--- a/librashader-cli/src/render/vk/mod.rs
+++ b/librashader-cli/src/render/vk/mod.rs
@@ -7,8 +7,8 @@ use gpu_allocator::MemoryLocation;
 use image::RgbaImage;
 use librashader::presets::ShaderPreset;
 use librashader::runtime::vk::{FilterChain, FilterChainOptions, FrameOptions, VulkanImage};
-use librashader::runtime::Viewport;
 use librashader::runtime::{FilterChainParameters, RuntimeParameters};
+use librashader::runtime::{Size, Viewport};
 use librashader_runtime::image::{Image, UVDirection, BGRA8};
 use std::path::Path;
 
@@ -32,10 +32,15 @@ impl RenderTest for Vulkan {
         Vulkan::new(path)
     }
 
+    fn image_size(&self) -> Size<u32> {
+        self.image_bytes.size
+    }
+
     fn render_with_preset_and_params(
         &mut self,
         preset: ShaderPreset,
         frame_count: usize,
+        output_size: Option<Size<u32>>,
         param_setter: Option<&dyn Fn(&RuntimeParameters)>,
         frame_options: Option<CommonFrameOptions>,
     ) -> anyhow::Result<image::RgbaImage> {
@@ -58,7 +63,7 @@ impl RenderTest for Vulkan {
             let image_info = vk::ImageCreateInfo::default()
                 .image_type(vk::ImageType::TYPE_2D)
                 .format(vk::Format::B8G8R8A8_UNORM)
-                .extent(self.image_bytes.size.into())
+                .extent(output_size.map_or(self.image_bytes.size.into(), |size| size.into()))
                 .mip_levels(1)
                 .array_layers(1)
                 .samples(vk::SampleCountFlags::TYPE_1)

--- a/librashader-cli/src/render/wgpu.rs
+++ b/librashader-cli/src/render/wgpu.rs
@@ -2,7 +2,7 @@ use crate::render::{CommonFrameOptions, RenderTest};
 use anyhow::anyhow;
 use image::RgbaImage;
 use librashader::runtime::wgpu::*;
-use librashader::runtime::Viewport;
+use librashader::runtime::{Size, Viewport};
 use librashader_runtime::image::{Image, UVDirection};
 use std::io::{Cursor, Write};
 use std::ops::DerefMut;
@@ -23,7 +23,7 @@ pub struct Wgpu {
     _adapter: Adapter,
     device: Arc<Device>,
     queue: Arc<Queue>,
-    _image: Image,
+    image: Image,
     texture: Arc<Texture>,
 }
 
@@ -56,10 +56,15 @@ impl RenderTest for Wgpu {
         Wgpu::new(path)
     }
 
+    fn image_size(&self) -> Size<u32> {
+        self.image.size
+    }
+
     fn render_with_preset_and_params(
         &mut self,
         preset: ShaderPreset,
         frame_count: usize,
+        output_size: Option<Size<u32>>,
         param_setter: Option<&dyn Fn(&RuntimeParameters)>,
         frame_options: Option<CommonFrameOptions>,
     ) -> anyhow::Result<image::RgbaImage> {
@@ -82,7 +87,7 @@ impl RenderTest for Wgpu {
 
         let output_tex = self.device.create_texture(&TextureDescriptor {
             label: None,
-            size: self.texture.size(),
+            size: output_size.map_or(self.texture.size(), |size| size.into()),
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
@@ -219,7 +224,7 @@ impl Wgpu {
                 _adapter: adapter,
                 device: Arc::new(device),
                 queue: Arc::new(queue),
-                _image: image,
+                image: image,
                 texture: Arc::new(texture),
             })
         })


### PR DESCRIPTION
currently broken in d3d11 and d3d12 for unknown reasons (possibly mtl too)