### PR TITLE
fix: create a history queue if required_images is 1

### DIFF
--- a/librashader-runtime/src/binding.rs
+++ b/librashader-runtime/src/binding.rs
@@ -395,6 +395,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct BindingRequirements {
     pub(crate) required_history: usize,
     pub(crate) uses_final_pass_as_feedback: bool,

--- a/librashader-runtime/src/framebuffer.rs
+++ b/librashader-runtime/src/framebuffer.rs
@@ -58,7 +58,10 @@ fn init_history<'a, F, I, E>(
     owned_generator: impl Fn() -> Result<F, E>,
     input_generator: impl Fn() -> I,
 ) -> Result<(VecDeque<F>, Box<[I]>), E> {
-    if required_images <= 1 {
+    // Since OriginalHistory0 aliases source, it always gets bound if present, and we don't need to
+    // store it. However, if even OriginalHistory1 is used, then we need to store it, hence we check if
+    // required_images is less than 1, and only then do we return an empty history queue.
+    if required_images < 1 {
         return Ok((VecDeque::new(), Box::new([])));
     }
 


### PR DESCRIPTION
Previously, if a shader used `OriginalHistory1` and no further history, we would not create enough space in the history queue.

Fixes https://github.com/raphamorim/rio/issues/788