### PR TITLE
rt(wgpu): allow arbitrary smart pointers around wgpu device objects

### DIFF
--- a/librashader-cli/src/render/wgpu.rs
+++ b/librashader-cli/src/render/wgpu.rs
@@ -70,8 +70,7 @@ impl RenderTest for Wgpu {
     ) -> anyhow::Result<image::RgbaImage> {
         let mut chain = FilterChain::load_from_preset(
             preset,
-            Arc::clone(&self.device),
-            Arc::clone(&self.queue),
+            (self.device.as_ref(), self.queue.as_ref()),
             Some(&FilterChainOptions {
                 force_no_mipmaps: false,
                 enable_cache: true,

--- a/librashader-runtime-wgpu/src/lib.rs
+++ b/librashader-runtime-wgpu/src/lib.rs
@@ -19,10 +19,15 @@ mod texture;
 mod util;
 
 pub use filter_chain::FilterChainWgpu;
+pub use filter_chain::WgpuDeviceObjects;
 pub use framebuffer::WgpuOutputView;
+
+pub use filter_chain::ArcDeviceObjects;
+pub use filter_chain::DeviceObjectsRef;
+pub use filter_chain::RcDeviceObjects;
 
 pub mod error;
 pub mod options;
 
 use librashader_runtime::impl_filter_chain_parameters;
-impl_filter_chain_parameters!(FilterChainWgpu);
+impl_filter_chain_parameters!(<P> FilterChainWgpu<P>);

--- a/librashader-runtime/src/parameters.rs
+++ b/librashader-runtime/src/parameters.rs
@@ -90,6 +90,13 @@ impl RuntimeParameters {
 
 #[macro_export]
 macro_rules! impl_filter_chain_parameters {
+    (<$gen:ident> $ty:ty) => {
+        impl<$gen> ::librashader_runtime::parameters::FilterChainParameters for $ty {
+            fn parameters(&self) -> &::librashader_runtime::parameters::RuntimeParameters {
+                &self.common.config
+            }
+        }
+    };
     ($ty:ty) => {
         impl ::librashader_runtime::parameters::FilterChainParameters for $ty {
             fn parameters(&self) -> &::librashader_runtime::parameters::RuntimeParameters {


### PR DESCRIPTION
This makes the wgpu frame functions take `WgpuDeviceObjects` , which yield a `&wgpu::Device` and `&wgpu::Queue`. 

This is to accommodate less expensive ways of storing the device and queue than an Arc