### PR TITLE
Various outstanding bugfixes + WGPU update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ dependencies = [
  "bytemuck",
  "librashader-preprocess",
  "librashader-reflect",
+ "parking_lot",
  "persy",
  "platform-dirs",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "52bca67b61cb81e5553babde81b8211f713cb6db79766f80168f3e5f40ea6c82"
 dependencies = [
  "ash",
  "raw-window-handle",
- "raw-window-metal",
+ "raw-window-metal 0.4.0",
 ]
 
 [[package]]
@@ -276,18 +276,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -573,7 +573,7 @@ dependencies = [
  "bitflags 1.3.2",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "foreign-types",
  "libc",
@@ -588,17 +588,17 @@ checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-foundation",
+ "core-graphics-types",
  "libc",
  "objc",
 ]
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
@@ -676,16 +676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,8 +688,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -711,18 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -1162,9 +1141,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1174,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "glslang"
-version = "0.6.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a8eb9fa5d381f25af800e9050ae38ed9d9b1f0a1d60722315475322f0ea3a9"
+checksum = "0db73ac0e8bd6f9c253b70205f2bb1c63845b6e263665ac8063316ce16f408c8"
 dependencies = [
  "bitflags 2.10.0",
  "glslang-sys",
@@ -1187,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "glslang-sys"
-version = "0.7.0+1062752"
+version = "0.8.1+275822a"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a2ca509c79db5c89d0a6fd91e146e00c815f40fe3a103247adfb24e0679d29"
+checksum = "ec80baca8831e8414db40c562fd76ca6a32a792c1db990451d4e7d3cb246e1ed"
 dependencies = [
  "cc",
  "glob",
@@ -1691,7 +1670,7 @@ dependencies = [
  "rspirv",
  "rustc-hash 2.1.1",
  "serde",
- "spirv",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "spirv-cross2",
  "spirv-to-dxil",
  "thiserror 2.0.18",
@@ -1953,21 +1932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
-dependencies = [
- "bitflags 2.10.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -2016,7 +1980,7 @@ dependencies = [
  "petgraph",
  "pp-rs",
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -2823,6 +2787,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,12 +2923,12 @@ dependencies = [
 
 [[package]]
 name = "rspirv"
-version = "0.12.0+sdk-1.3.268.0"
+version = "0.13.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cf3a93856b6e5946537278df0d3075596371b1950ccff012f02b0f7eafec8d"
+checksum = "091dca2e1d6fd3098417b5ec88e77e80d1ba5945750943419dc976858082c296"
 dependencies = [
  "rustc-hash 1.1.0",
- "spirv",
+ "spirv 0.4.0+sdk-1.4.341.0",
 ]
 
 [[package]]
@@ -3217,10 +3193,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv-cross-sys"
-version = "0.6.1+bf6bb5c"
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f62cba64200088a7458bb700a2622d440420cb84c7c347e2b25f65850bbded3"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "spirv-cross-sys"
+version = "0.7.2+38681a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9291b270f65ee1e61842d0a4dadc707d3b1669d8001e0900433e341c897d5d1b"
 dependencies = [
  "bytemuck",
  "cc",
@@ -3230,14 +3215,14 @@ dependencies = [
 
 [[package]]
 name = "spirv-cross2"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696259e05494c2b1dad12286cf545071af01a3802ab44e069e2d33bb9b393b58"
+checksum = "7e01f93f6f1637a1a72b43d2ca50ebbcd94c3f4c4e94eda8e27144834671f008"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "memchr",
- "spirv",
+ "spirv 0.4.0+sdk-1.4.341.0",
  "spirv-cross-sys",
  "spirv-cross2-derive",
  "thiserror 1.0.69",
@@ -3289,7 +3274,7 @@ dependencies = [
  "half",
  "num-traits",
  "ordered-float 4.6.0",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
 ]
 
 [[package]]
@@ -3810,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -3840,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb4c8b5db5f00e56f1f08869d870a0dff7c8bc7ebc01091fec140b0cf0211a9"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -3867,52 +3852,52 @@ dependencies = [
  "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293080d77fdd14d6b08a67c5487dfddbf874534bb7921526db56a7b75d7e3bef"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
  "bitflags 2.10.0",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases 0.2.1",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
@@ -3923,10 +3908,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
  "ndk-sys 0.6.0+11769913",
- "objc",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
  "once_cell",
  "ordered-float 5.1.0",
  "parking_lot",
@@ -3935,26 +3923,41 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal 1.1.0",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
  "windows",
  "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "28.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
  "js-sys",
  "log",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -4332,7 +4335,7 @@ dependencies = [
  "bytemuck",
  "calloop",
  "cfg_aliases 0.1.1",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "icrate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,12 +460,12 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "log",
  "proc-macro2",
@@ -474,7 +474,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -543,7 +543,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1313,6 +1313,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2706,7 +2712,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3092,11 +3098,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3452,23 +3458,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3482,44 +3482,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "triomphe"
@@ -4389,6 +4375,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ resolver = "2"
 windows = "0.62"
 windows-core = "0.62"
 ash = "0.38"
-spirv-cross2 = { version = "0.6", default-features = false }
+spirv-cross2 = { version = "0.7.0", default-features = false }
 objc2-metal = { version = "0.3" }
 objc2 = { version = "0.6" }
-glow = { version = "0.16.0" }
+glow = { version = "0.17.0" }
 glfw = { version = "0.59.0" }
 
-wgpu = { version = "28", default-features = false }
-wgpu-types = { version = "28" }
+wgpu = { version = "29.0.3", default-features = false }
+wgpu-types = { version = "29.0.3" }
 
 clap = { version = "=4.3.0", features = ["derive"] }
 rayon = { version = "1.10.0"}

--- a/README.md
+++ b/README.md
@@ -21,25 +21,21 @@ Direct3D 11, Direct3D 12, and Metal.
 librashader does not support legacy render APIs such as older versions of OpenGL or Direct3D, except for limited
 support for Direct3D 9.
 
-| **API**     | **Status**  | **`librashader` feature** |
-|-------------|-------------|---------------------------|
-| OpenGL 3.3+ | ✅          | `gl`                      |
-| OpenGL 4.6  | ✅          | `gl`                      |
-| Vulkan      | ✅          | `vk`                      |
-| Direct3D 9  | 🆗️          | `d3d9`                    |
-| Direct3D 11 | ✅          | `d3d11`                   |
-| Direct3D 12 | ✅          | `d3d12`                   |
-| Metal       | ✅          | `metal`                   |
-| wgpu        | ✅†         | `wgpu`                    |
+| **API**     | **Status** | **`librashader` feature** |
+|-------------|------------|---------------------------|
+| OpenGL 3.3+ | ✅         | `gl`                      |
+| OpenGL 4.6  | ✅         | `gl`                      |
+| Vulkan      | ✅         | `vk`                      |
+| Direct3D 9  | 🆗️         | `d3d9`                    |
+| Direct3D 11 | ✅         | `d3d11`                   |
+| Direct3D 12 | ✅         | `d3d12`                   |
+| Metal       | ✅         | `metal`                   |
+| wgpu        | ✅         | `wgpu`                    |
 
 ✅ Full Support &mdash; 🆗 Secondary Support 
 
 Shader compatibility is not guaranteed on render APIs with secondary support. In particular, Direct3D 9 does not support
 shaders that need Direct3D 10+ only features, or shaders that can not be compiled to [Shader Model 3.0](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/shader-model-3).
-
-†wgpu does not support [FSR shaders](https://github.com/libretro/slang-shaders/tree/master/edge-smoothing/fsr). This is blocking on 
-support for [parsing `ImageGather` operations](https://github.com/gfx-rs/wgpu/issues/4538) in wgpu. Some shaders also require [`FLOAT32_FILTERABLE`](https://docs.rs/wgpu/latest/wgpu/struct.Features.html#associatedconstant.FLOAT32_FILTERABLE)
-to be enabled.
 
 ## Usage
 
@@ -224,6 +220,8 @@ Please report an issue if you run into a shader that works in RetroArch, but not
   * Allocations within the runtime are done through [gpu-allocator](https://github.com/Traverse-Research/gpu-allocator) rather than handled manually.
 * Direct3D 11
   * Framebuffer copies are done via `ID3D11DeviceContext::CopySubresourceRegion` rather than a CPU conversion + copy.
+  * Shader Model 4.0 to 5.1 do not support `sample` calls in a non-uniform loop. These are lowered to `sampleLod` before being
+    passed to the DirectX Shader Compiler. These shaders would usually fail to compile in RetroArch.
 * Direct3D 12
   * The Direct3D 12 runtime uses [render passes](https://learn.microsoft.com/en-us/windows/win32/direct3d12/direct3d-12-render-passes). This feature has been available since Windows 10 version 1809,
     which was released in late 2018.

--- a/include/librashader.h
+++ b/include/librashader.h
@@ -521,6 +521,8 @@ typedef struct filter_chain_d3d12_opt_t {
   /// Disable the shader object cache. Shaders will be
   /// recompiled rather than loaded from the cache.
   bool disable_cache;
+  /// The number of frames in flight to keep. If zero, defaults to three.
+  uint32_t frames_in_flight;
 } filter_chain_d3d12_opt_t;
 #endif
 
@@ -1186,7 +1188,9 @@ typedef libra_error_t (*PFN_libra_mtl_filter_chain_free)(libra_mtl_filter_chain_
 /// - API version 2: 0.6.0
 ///     - Added original aspect uniforms
 ///     - Added frame time uniforms
-#define LIBRASHADER_CURRENT_VERSION 2
+/// - API version 3: 0.10.0
+///     - Added frames_in_flight to Direct3D 12 filter chain options
+#define LIBRASHADER_CURRENT_VERSION 3
 
 /// The current version of the librashader ABI.
 /// Used by the loader to check ABI compatibility.

--- a/librashader-build-script/Cargo.toml
+++ b/librashader-build-script/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 
 [dependencies]
-cbindgen = "0.27.0"
+cbindgen = "0.29.2"
 clap = { workspace = true }
 carlog = "0.1.0"
 

--- a/librashader-cache/Cargo.toml
+++ b/librashader-cache/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "2"
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 persy = "1.6.0"
 
+parking_lot = "0.12.5"
 bytemuck = "1.13.0"
 
 [target.x86_64-win7-windows-msvc.dependencies.blake3]

--- a/librashader-cache/src/cache.rs
+++ b/librashader-cache/src/cache.rs
@@ -14,7 +14,7 @@ pub(crate) mod internal {
     use std::error::Error;
     use std::panic::catch_unwind;
     use std::path::PathBuf;
-
+    use std::sync::OnceLock;
     use persy::{ByteVec, Config, Persy, ValueMode};
     use thiserror::Error;
 
@@ -63,7 +63,13 @@ pub(crate) mod internal {
 
     pub(crate) fn get_cache() -> Result<Persy, Box<dyn Error>> {
         let cache_dir = get_cache_dir()?;
-        match catch_unwind(|| {
+        static CACHE: OnceLock<Persy> = OnceLock::new();
+
+        if let Some(persy) = CACHE.get() {
+            return Ok(persy.clone());
+        }
+
+        let persy = match catch_unwind(|| {
             Persy::open_or_create_with(
                 &cache_dir.join("librashader.db.1"),
                 Config::new(),
@@ -74,7 +80,7 @@ pub(crate) mod internal {
                 },
             )
         }) {
-            Ok(Ok(conn)) => Ok(conn),
+            Ok(Ok(conn)) => Ok::<_, Box<dyn Error>>(conn),
             Ok(Err(e)) => {
                 remove_cache();
                 Err(e)?
@@ -83,7 +89,9 @@ pub(crate) mod internal {
                 remove_cache();
                 Err(CatchPanicError::Panic(e))?
             }
-        }
+        }?;
+
+        Ok(CACHE.get_or_init(move || persy).clone())
     }
 
     pub(crate) fn get_blob(

--- a/librashader-cache/src/cache.rs
+++ b/librashader-cache/src/cache.rs
@@ -15,6 +15,7 @@ pub(crate) mod internal {
     use std::panic::catch_unwind;
     use std::path::PathBuf;
     use std::sync::OnceLock;
+    use parking_lot::Mutex;
     use persy::{ByteVec, Config, Persy, ValueMode};
     use thiserror::Error;
 
@@ -113,6 +114,10 @@ pub(crate) mod internal {
         key: &[u8],
         value: &[u8],
     ) -> Result<(), Box<dyn Error>> {
+        static WRITE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let write_lock = WRITE_LOCK.get_or_init(|| Mutex::new(()));
+        let _guard = write_lock.lock();
+
         let mut tx = conn.begin()?;
         if !tx.exists_index(index)? {
             tx.create_index::<ByteVec, ByteVec>(index, ValueMode::Replace)?;

--- a/librashader-cache/src/cache.rs
+++ b/librashader-cache/src/cache.rs
@@ -9,14 +9,14 @@ pub(crate) mod internal {
         Panic(Box<dyn Any + Send + 'static>),
     }
 
+    use parking_lot::Mutex;
+    use persy::{ByteVec, Config, Persy, ValueMode};
     use platform_dirs::AppDirs;
     use std::any::Any;
     use std::error::Error;
     use std::panic::catch_unwind;
     use std::path::PathBuf;
     use std::sync::OnceLock;
-    use parking_lot::Mutex;
-    use persy::{ByteVec, Config, Persy, ValueMode};
     use thiserror::Error;
 
     pub(crate) fn get_cache_dir() -> Result<PathBuf, Box<dyn Error>> {

--- a/librashader-capi/src/runtime/d3d12/filter_chain.rs
+++ b/librashader-capi/src/runtime/d3d12/filter_chain.rs
@@ -132,11 +132,15 @@ pub struct filter_chain_d3d12_opt_t {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+
+    /// The number of frames in flight to keep. If zero, defaults to three.
+    pub frames_in_flight: u32,
 }
 
 config_struct! {
     impl FilterChainOptions => filter_chain_d3d12_opt_t {
         0 =>  [force_hlsl_pipeline, force_no_mipmaps, disable_cache];
+        3 =>  [frames_in_flight];
     }
 }
 

--- a/librashader-capi/src/version.rs
+++ b/librashader-capi/src/version.rs
@@ -21,7 +21,9 @@ pub type LIBRASHADER_ABI_VERSION = usize;
 /// - API version 2: 0.6.0
 ///     - Added original aspect uniforms
 ///     - Added frame time uniforms
-pub const LIBRASHADER_CURRENT_VERSION: LIBRASHADER_API_VERSION = 2;
+/// - API version 3: 0.10.0
+///     - Added frames_in_flight to Direct3D 12 filter chain options
+pub const LIBRASHADER_CURRENT_VERSION: LIBRASHADER_API_VERSION = 3;
 
 /// The current version of the librashader ABI.
 /// Used by the loader to check ABI compatibility.

--- a/librashader-cli/src/render/d3d12/mod.rs
+++ b/librashader-cli/src/render/d3d12/mod.rs
@@ -89,6 +89,7 @@ impl RenderTest for Direct3D12 {
                     force_hlsl_pipeline: false,
                     force_no_mipmaps: false,
                     disable_cache: false,
+                    frames_in_flight: 3,
                 }),
             )?;
 

--- a/librashader-cli/src/render/mod.rs
+++ b/librashader-cli/src/render/mod.rs
@@ -107,7 +107,7 @@ mod test {
 
     fn do_test<T: RenderTest>() -> anyhow::Result<()> {
         let mut test = T::new(IMAGE_PATH.as_ref())?;
-        let image = test.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100)?;
+        let image = test.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100, None)?;
 
         let out = File::create("out.png")?;
         image.write_with_encoder(PngEncoder::new(out))?;
@@ -166,8 +166,8 @@ mod test {
         let mut a = A::new(IMAGE_PATH.as_ref())?;
         let mut b = B::new(IMAGE_PATH.as_ref())?;
 
-        let a_image = a.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100)?;
-        let b_image = b.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100)?;
+        let a_image = a.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100, None)?;
+        let b_image = b.render(FILTER_PATH.as_ref(), ShaderFeatures::NONE, 100, None)?;
 
         let similarity = image_compare::rgba_hybrid_compare(&a_image, &b_image)?;
         assert!(similarity.score > 0.95);

--- a/librashader-common/src/string.rs
+++ b/librashader-common/src/string.rs
@@ -21,25 +21,30 @@ impl Deref for ParamString {
 impl From<&str> for ParamString {
     #[inline]
     fn from(s: &str) -> Self {
-        ParamString(SharedString::try_from(s)
-            .expect("ParamString with more than 4294967295 characters. Parameter too large."))
+        ParamString(
+            SharedString::try_from(s)
+                .expect("ParamString with more than 4294967295 characters. Parameter too large."),
+        )
     }
 }
 
 impl From<&String> for ParamString {
     #[inline]
     fn from(s: &String) -> Self {
-        ParamString(SharedString::try_from(s)
-            .expect("ParamString with more than 4294967295 characters. Parameter too large."))
+        ParamString(
+            SharedString::try_from(s)
+                .expect("ParamString with more than 4294967295 characters. Parameter too large."),
+        )
     }
 }
-
 
 impl From<String> for ParamString {
     #[inline]
     fn from(s: String) -> Self {
-        ParamString(SharedString::try_from(s)
-            .expect("ParamString with more than 4294967295 characters. Parameter too large."))
+        ParamString(
+            SharedString::try_from(s)
+                .expect("ParamString with more than 4294967295 characters. Parameter too large."),
+        )
     }
 }
 
@@ -99,7 +104,6 @@ impl PartialEq<ParamString> for &String {
     }
 }
 
-
 impl Eq for ParamString {}
 
 impl PartialOrd<String> for ParamString {
@@ -120,15 +124,14 @@ impl PartialOrd<&str> for ParamString {
     }
 }
 
-
 impl ParamString {
     /// Pushes a new string onto the `ParamString`.
     ///
     /// This could incur up to two allocations.
     pub fn push_str(&mut self, s: &str) {
-        let new= format!("{self}{s}");
-        self.0 = SharedString::try_from(new)
-            .expect("ParamString with more than 4294967295 characters.");
+        let new = format!("{self}{s}");
+        self.0 =
+            SharedString::try_from(new).expect("ParamString with more than 4294967295 characters.");
     }
 
     // Extracts a string slice containing the entire `ParamString`.

--- a/librashader-presets/src/parse/value.rs
+++ b/librashader-presets/src/parse/value.rs
@@ -362,12 +362,14 @@ pub fn parse_values(
         })
         .map_or_else(|| Ok(false), |(_, v)| from_bool(v.value))?;
 
+        // For LUTs, only, defaults LUT filtering to LINEAR when `<Texture>_linear` is absent.
+        // This matches RetroArch LUT filtering behaviour
         let linear = remove_if(&mut tokens, |(_, t)| {
             t.key.starts_with(*texture)
                 && t.key.ends_with("_linear")
                 && t.key.len() == texture.len() + "_linear".len()
         })
-        .map_or_else(|| Ok(false), |(_, v)| from_bool(v.value))?;
+        .map_or_else(|| Ok(true), |(_, v)| from_bool(v.value))?;
 
         let wrap_mode = remove_if(&mut tokens, |(_, t)| {
             t.key.starts_with(*texture)
@@ -598,7 +600,7 @@ pub fn parse_values(
                 && t.key.ends_with("_linear")
                 && t.key.len() == texture.len() + "_linear".len()
         })
-        .map_or_else(|| Ok(false), |(_, v)| from_bool(v.value))?;
+        .map_or_else(|| Ok(true), |(_, v)| from_bool(v.value))?;
 
         let wrap_mode = remove_if(&mut rest_tokens, |(_, t)| {
             t.key.starts_with(*texture)

--- a/librashader-reflect/Cargo.toml
+++ b/librashader-reflect/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["shader", "retroarch", "SPIR-V"]
 description = "RetroArch shaders for all."
 
 [dependencies]
-glslang = "0.6.0"
+glslang = "0.8.1"
 bytemuck = "1.13.0"
 
 thiserror = "2"
@@ -25,9 +25,9 @@ librashader-pack = { path = "../librashader-pack", version = "0.10.1" }
 
 spirv-cross2 = { workspace = true, optional = true }
 
-naga = { version = "28", optional = true }
-rspirv = { version = "0.12.0", optional = true }
-spirv = { version = "0.3.0", optional = true}
+naga = { version = "29", optional = true }
+rspirv = { version = "0.13.0+sdk-1.4.341.0", optional = true }
+spirv = { version = "0.4.0+sdk-1.4.341.0", optional = true}
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 rustc-hash = "2.0.0"

--- a/librashader-reflect/src/back/hlsl.rs
+++ b/librashader-reflect/src/back/hlsl.rs
@@ -2,7 +2,7 @@ use crate::back::targets::HLSL;
 use crate::back::{CompileReflectShader, CompilerBackend, FromCompilation};
 use crate::error::ShaderReflectError;
 use crate::front::SpirvCompilation;
-use crate::reflect::cross::hlsl::HlslReflect;
+use crate::reflect::cross::hlsl::HlslCompileShader;
 use crate::reflect::cross::{CompiledProgram, SpirvCross};
 
 /// The HLSL shader model version to target.
@@ -114,7 +114,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
         compile: SpirvCompilation,
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
-            backend: HlslReflect::try_from(&compile)?,
+            backend: HlslCompileShader::new(compile)?,
         })
     }
 }
@@ -130,7 +130,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
         compile: SpirvCompilation,
     ) -> Result<CompilerBackend<Self::Output>, ShaderReflectError> {
         Ok(CompilerBackend {
-            backend: Box::new(HlslReflect::try_from(&compile)?),
+            backend: Box::new(HlslCompileShader::new(compile)?),
         })
     }
 }

--- a/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
+++ b/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
@@ -176,7 +176,7 @@ impl<'a> HardenNormalize<'a> {
 
                     let fadd_id = self.builder.id();
                     new_instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(Op::FAdd),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(Op::FAdd),
                         result_type: Some(result_type),
                         result_id: Some(fadd_id),
                         operands: vec![Operand::IdRef(input_id), Operand::IdRef(eps_id)],
@@ -207,5 +207,5 @@ fn is_normalize(instr: &Instruction, ext_set: Word) -> bool {
     let Some(Operand::LiteralExtInstInteger(opc)) = instr.operands.get(1) else {
         return false;
     };
-    *opc == spirv::GLOp::Normalize as u32
+    *opc == spirv::GlslStd450Op::Normalize as u32
 }

--- a/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
+++ b/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
@@ -1,0 +1,209 @@
+//! Workaround for an FXC bug where SM3 rejects NaN/inf literals that the
+//! compiler itself produces via aggressive constant folding.
+//!
+//! Walking the SPIR-V, this pass wraps every `OpExtInst Normalize %vec`
+//! with an `OpFAdd %vec %eps` to work around the FXC bug.
+//!
+//! For non-zero inputs the perturbation (≈1e-7 per component) is
+//! lost in normalization; for zero inputs the result is now a finite
+//! near-unit vector instead of NaN.
+//!
+//! This pass should only be run when generating SM3 HLSL.
+
+use rspirv::dr::{Builder, Instruction, Operand};
+use rustc_hash::{FxHashMap, FxHashSet};
+use spirv::{Op, Word};
+
+/// Per-component epsilon added to vectors before they are passed to `Normalize`.
+/// Small enough to be lost in re-normalization for non-zero inputs, large enough
+/// to keep `normalize((0,..,0))` from collapsing to NaN under FXC's folding.
+const NORMALIZE_EPSILON: f32 = 1e-7;
+
+pub struct HardenNormalize<'a> {
+    pub builder: &'a mut Builder,
+}
+
+impl<'a> HardenNormalize<'a> {
+    pub fn new(builder: &'a mut Builder) -> Self {
+        Self { builder }
+    }
+
+    pub fn do_pass(&mut self) {
+        let Some(ext_set) = self.find_glsl_std_450() else {
+            return;
+        };
+
+        let result_types = self.collect_normalize_result_types(ext_set);
+        if result_types.is_empty() {
+            return;
+        }
+
+        let epsilon_constants = self.create_epsilon_constants(&result_types);
+        self.rewrite_normalize_calls(ext_set, &epsilon_constants);
+    }
+
+    fn find_glsl_std_450(&self) -> Option<Word> {
+        for instr in &self.builder.module_ref().ext_inst_imports {
+            if instr.class.opcode != Op::ExtInstImport {
+                continue;
+            }
+            if let Some(Operand::LiteralString(name)) = instr.operands.first() {
+                if name == "GLSL.std.450" {
+                    return instr.result_id;
+                }
+            }
+        }
+        None
+    }
+
+    /// Collect the result-type id of every `OpExtInst Normalize` in the module.
+    /// For `Normalize` the result type equals the input vector type.
+    fn collect_normalize_result_types(&self, ext_set: Word) -> FxHashSet<Word> {
+        let mut types = FxHashSet::default();
+        for function in &self.builder.module_ref().functions {
+            for block in &function.blocks {
+                for instr in &block.instructions {
+                    if !is_normalize(instr, ext_set) {
+                        continue;
+                    }
+                    if let Some(result_type) = instr.result_type {
+                        types.insert(result_type);
+                    }
+                }
+            }
+        }
+        types
+    }
+
+    /// Build (or look up) an epsilon constant for each vector/scalar type used
+    /// as a `Normalize` operand. Returns a map from type id → constant id.
+    fn create_epsilon_constants(&mut self, types: &FxHashSet<Word>) -> FxHashMap<Word, Word> {
+        let mut result = FxHashMap::default();
+        // Cache scalar epsilons by float-type id so we don't rebuild them.
+        let mut scalar_eps_by_float_type: FxHashMap<Word, Word> = FxHashMap::default();
+
+        for &type_id in types {
+            let Some((float_type, component_count)) = self.float_type_and_count(type_id) else {
+                continue;
+            };
+
+            let eps_scalar = *scalar_eps_by_float_type.entry(float_type).or_insert_with(|| {
+                self.builder
+                    .constant_bit32(float_type, NORMALIZE_EPSILON.to_bits())
+            });
+
+            let composite = if component_count == 1 {
+                eps_scalar
+            } else {
+                let constituents = vec![eps_scalar; component_count as usize];
+                self.builder.constant_composite(type_id, constituents)
+            };
+
+            result.insert(type_id, composite);
+        }
+
+        result
+    }
+
+    /// Resolve `type_id` to its underlying `(float_type_id, component_count)`.
+    /// Returns `None` if the type isn't a float scalar or float vector.
+    fn float_type_and_count(&self, type_id: Word) -> Option<(Word, u32)> {
+        let type_instr = self
+            .builder
+            .module_ref()
+            .types_global_values
+            .iter()
+            .find(|i| i.result_id == Some(type_id))?;
+
+        match type_instr.class.opcode {
+            Op::TypeFloat => Some((type_id, 1)),
+            Op::TypeVector => {
+                let component_type = type_instr.operands.first()?.id_ref_any()?;
+                let count = match type_instr.operands.get(1)? {
+                    Operand::LiteralBit32(n) => *n,
+                    _ => return None,
+                };
+
+                // Verify the component type is actually a float — Normalize on
+                // integer vectors is invalid SPIR-V, but be defensive.
+                let comp_instr = self
+                    .builder
+                    .module_ref()
+                    .types_global_values
+                    .iter()
+                    .find(|i| i.result_id == Some(component_type))?;
+                if comp_instr.class.opcode != Op::TypeFloat {
+                    return None;
+                }
+                Some((component_type, count))
+            }
+            _ => None,
+        }
+    }
+
+    /// For every `OpExtInst Normalize %input`, insert
+    /// `%input' = OpFAdd %input %eps` just before it and rewrite the operand.
+    fn rewrite_normalize_calls(
+        &mut self,
+        ext_set: Word,
+        epsilon_constants: &FxHashMap<Word, Word>,
+    ) {
+        let mut functions = std::mem::take(&mut self.builder.module_mut().functions);
+
+        for function in functions.iter_mut() {
+            for block in function.blocks.iter_mut() {
+                let mut new_instructions = Vec::with_capacity(block.instructions.len());
+                for instr in block.instructions.drain(..) {
+                    if !is_normalize(&instr, ext_set) {
+                        new_instructions.push(instr);
+                        continue;
+                    }
+
+                    let Some(result_type) = instr.result_type else {
+                        new_instructions.push(instr);
+                        continue;
+                    };
+                    let Some(&eps_id) = epsilon_constants.get(&result_type) else {
+                        new_instructions.push(instr);
+                        continue;
+                    };
+                    let Some(Operand::IdRef(input_id)) = instr.operands.get(2).cloned() else {
+                        new_instructions.push(instr);
+                        continue;
+                    };
+
+                    let fadd_id = self.builder.id();
+                    new_instructions.push(Instruction {
+                        class: rspirv::grammar::CoreInstructionTable::get(Op::FAdd),
+                        result_type: Some(result_type),
+                        result_id: Some(fadd_id),
+                        operands: vec![Operand::IdRef(input_id), Operand::IdRef(eps_id)],
+                    });
+
+                    let mut new_normalize = instr;
+                    new_normalize.operands[2] = Operand::IdRef(fadd_id);
+                    new_instructions.push(new_normalize);
+                }
+                block.instructions = new_instructions;
+            }
+        }
+
+        self.builder.module_mut().functions = functions;
+    }
+}
+
+fn is_normalize(instr: &Instruction, ext_set: Word) -> bool {
+    if instr.class.opcode != Op::ExtInst {
+        return false;
+    }
+    let Some(Operand::IdRef(set)) = instr.operands.first() else {
+        return false;
+    };
+    if *set != ext_set {
+        return false;
+    }
+    let Some(Operand::LiteralExtInstInteger(opc)) = instr.operands.get(1) else {
+        return false;
+    };
+    *opc == spirv::GLOp::Normalize as u32
+}

--- a/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
+++ b/librashader-reflect/src/front/spirv_passes/harden_normalize.rs
@@ -87,10 +87,12 @@ impl<'a> HardenNormalize<'a> {
                 continue;
             };
 
-            let eps_scalar = *scalar_eps_by_float_type.entry(float_type).or_insert_with(|| {
-                self.builder
-                    .constant_bit32(float_type, NORMALIZE_EPSILON.to_bits())
-            });
+            let eps_scalar = *scalar_eps_by_float_type
+                .entry(float_type)
+                .or_insert_with(|| {
+                    self.builder
+                        .constant_bit32(float_type, NORMALIZE_EPSILON.to_bits())
+                });
 
             let composite = if component_count == 1 {
                 eps_scalar

--- a/librashader-reflect/src/front/spirv_passes/link_input_outputs.rs
+++ b/librashader-reflect/src/front/spirv_passes/link_input_outputs.rs
@@ -214,7 +214,7 @@ impl<'a> LinkInputs<'a> {
                 // downgrade the OpVariable if it's in dead_outputs
                 global.operands[0] = Operand::StorageClass(StorageClass::Private);
 
-                // Get the result type. If there's no result type it's invalid anyways
+                // Get the result type. If there's no result type it's invalid anyway
                 // so it doesn't matter that we downgraded early (better downgraded than unmatched)
                 let Some(result_type) = &mut global.result_type else {
                     continue;
@@ -236,7 +236,22 @@ impl<'a> LinkInputs<'a> {
                 return true;
             }
 
-            let Some(Operand::Decoration(Decoration::Location)) = op.operands.get(1) else {
+            // IO decorations are not permitted on private members.
+            let Some(Operand::Decoration(
+                Decoration::Location
+                | Decoration::Component
+                | Decoration::Index
+                | Decoration::NoPerspective
+                | Decoration::Flat
+                | Decoration::Centroid
+                | Decoration::Sample
+                | Decoration::Patch
+                | Decoration::Invariant
+                | Decoration::Stream
+                | Decoration::XfbBuffer
+                | Decoration::XfbStride,
+            )) = op.operands.get(1)
+            else {
                 return true;
             };
 

--- a/librashader-reflect/src/front/spirv_passes/lower_loop_sample_lod.rs
+++ b/librashader-reflect/src/front/spirv_passes/lower_loop_sample_lod.rs
@@ -322,7 +322,7 @@ impl<'a> LowerLoopSampleLod<'a> {
                 }
             }
         }
-        self.builder.type_float(32)
+        self.builder.type_float(32, None)
     }
 }
 
@@ -555,11 +555,11 @@ fn is_per_thread_op(op: Op) -> bool {
 fn convert_implicit_to_explicit(instr: &mut Instruction, lod_zero: Word) {
     match instr.class.opcode {
         Op::ImageSampleImplicitLod => {
-            instr.class = rspirv::grammar::CoreInstructionTable::get(Op::ImageSampleExplicitLod);
+            instr.class = rspirv::grammar::INSTRUCTION_TABLE.get(Op::ImageSampleExplicitLod);
         }
         Op::ImageSparseSampleImplicitLod => {
             instr.class =
-                rspirv::grammar::CoreInstructionTable::get(Op::ImageSparseSampleExplicitLod);
+                rspirv::grammar::INSTRUCTION_TABLE.get(Op::ImageSparseSampleExplicitLod);
         }
         _ => return,
     }

--- a/librashader-reflect/src/front/spirv_passes/lower_loop_sample_lod.rs
+++ b/librashader-reflect/src/front/spirv_passes/lower_loop_sample_lod.rs
@@ -1,0 +1,575 @@
+//! Workaround for an FXC limitation: in HLSL Shader Model 5 (and earlier),
+//! a gradient-emitting texture sample (`Sample`, `SampleBias`, `SampleCmp`)
+//! is illegal inside a loop whose iteration count is non-uniform — and the
+//! compiler refuses to unroll loops whose worst-case bound is too large
+//! (error X3511). The slang-shaders blur passes in `crt-yah` trip this
+//! because the loop bounds are interpolated vertex outputs.
+//!
+//! SPIRV-Cross emits `OpImageSampleImplicitLod` (implicit gradient) from
+//! `texture(s, uv)` calls. This pass walks the SPIR-V CFG, finds every
+//! `OpImageSampleImplicitLod` (and the Sparse counterpart) that lives
+//! inside a **non-uniform** structured loop, and rewrites it to
+//! `OpImageSampleExplicitLod` with `Lod = 0`. The resulting HLSL emits
+//! `SampleLevel(s, uv, 0)`, which carries an explicit LOD and is therefore
+//! legal in a dynamic loop under FXC.
+//!
+//! "Non-uniform" here means the loop's termination condition transitively
+//! depends on a value sourced from an `Input` storage variable (interpolated
+//! vertex output / fragment-stage input), a previous texture sample, or a
+//! derivative op. Loops bounded by constants or uniform/push-constant values
+//! are left alone — FXC unrolls those fine and we don't want to spuriously
+//! lose mipmap selection on a uniform loop that just happens to contain a
+//! sample.
+//!
+//! Trade-off: samples inside non-uniform loops lose mipmap selection on
+//! this path. Practically this affects only previous-pass outputs (rarely
+//! mipmapped) and LUTs (almost never sampled inside a loop), so the visual
+//! impact is negligible — and strictly better than the shader failing to
+//! compile.
+
+use rspirv::dr::{Builder, Function, Instruction, Operand};
+use rustc_hash::{FxHashMap, FxHashSet};
+use spirv::{ImageOperands, Op, StorageClass, Word};
+
+pub struct LowerLoopSampleLod<'a> {
+    pub builder: &'a mut Builder,
+}
+
+impl<'a> LowerLoopSampleLod<'a> {
+    pub fn new(builder: &'a mut Builder) -> Self {
+        Self { builder }
+    }
+
+    pub fn do_pass(&mut self) {
+        // 1. Build a set of SSA value ids and variable ids that hold
+        //    non-uniform data (per-fragment varyings, sample/derivative
+        //    results, etc).
+        let non_uniform = self.collect_non_uniform_ids();
+
+        // 2. Find the blocks that sit inside a structured loop whose
+        //    iteration count is non-uniform. Loops with uniform bounds
+        //    are skipped — FXC handles them fine and we'd rather not
+        //    lose mipmap selection unnecessarily.
+        let in_loop = self.collect_in_nonuniform_loop_blocks(&non_uniform);
+        if in_loop.is_empty() {
+            return;
+        }
+
+        // 3. Identify candidate ImplicitLod samples we can safely lower.
+        //    Collect indices first so we can mutate the module afterwards
+        //    without invalidating iteration.
+        let mut rewrites: Vec<(usize, usize, usize)> = Vec::new();
+        for (fi, function) in self.builder.module_ref().functions.iter().enumerate() {
+            for (bi, block) in function.blocks.iter().enumerate() {
+                let Some(label_id) = block.label_id() else {
+                    continue;
+                };
+                if !in_loop.contains(&label_id) {
+                    continue;
+                }
+                for (ii, instr) in block.instructions.iter().enumerate() {
+                    if is_lowerable_implicit_sample(instr) {
+                        rewrites.push((fi, bi, ii));
+                    }
+                }
+            }
+        }
+
+        if rewrites.is_empty() {
+            return;
+        }
+
+        // 4. Find or create the LOD constant, then rewrite the instructions.
+        let float_type = self.find_or_make_float_type();
+        let lod_zero = self.builder.constant_bit32(float_type, 0u32);
+        for (fi, bi, ii) in rewrites {
+            let instr = &mut self.builder.module_mut().functions[fi].blocks[bi].instructions[ii];
+            convert_implicit_to_explicit(instr, lod_zero);
+        }
+    }
+
+    /// Conservative non-uniformity dataflow.
+    ///
+    /// Starting from declared non-uniform sources (Input-class variables
+    /// and texture/derivative ops), iterate to fixed-point propagating
+    /// non-uniformness through OpLoad, OpStore, OpAccessChain, and any
+    /// other op whose result-id consumes a non-uniform IdRef.
+    ///
+    /// We err on the side of marking too much — false positives only
+    /// cost us the ability to skip a rewrite that was already safe, while
+    /// false negatives would skip rewriting a loop that FXC can't compile.
+    fn collect_non_uniform_ids(&self) -> FxHashSet<Word> {
+        let module = self.builder.module_ref();
+        let mut non_uniform: FxHashSet<Word> = FxHashSet::default();
+
+        // Seed: every `Input`-class OpVariable is non-uniform (it's the
+        // per-fragment interpolated value). OpVariables in other storage
+        // classes default to uniform and only become non-uniform via a
+        // non-uniform OpStore (handled in the propagation loop below).
+        for instr in &module.types_global_values {
+            if instr.class.opcode != Op::Variable {
+                continue;
+            }
+            let Some(Operand::StorageClass(sc)) = instr.operands.first() else {
+                continue;
+            };
+            if matches!(*sc, StorageClass::Input) {
+                if let Some(id) = instr.result_id {
+                    non_uniform.insert(id);
+                }
+            }
+        }
+
+        // Propagate.
+        loop {
+            let mut changed = false;
+
+            for function in &module.functions {
+                for block in &function.blocks {
+                    for instr in &block.instructions {
+                        // OpStore propagates non-uniformness from value
+                        // into the pointer's underlying variable.
+                        if instr.class.opcode == Op::Store {
+                            let (Some(Operand::IdRef(ptr)), Some(Operand::IdRef(val))) =
+                                (instr.operands.first(), instr.operands.get(1))
+                            else {
+                                continue;
+                            };
+                            if non_uniform.contains(val) {
+                                // Mark the pointer itself plus the root
+                                // variable it transitively points to.
+                                if non_uniform.insert(*ptr) {
+                                    changed = true;
+                                }
+                                if let Some(root) = root_variable(*ptr, module) {
+                                    if non_uniform.insert(root) {
+                                        changed = true;
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
+                        let Some(result_id) = instr.result_id else {
+                            continue;
+                        };
+                        if non_uniform.contains(&result_id) {
+                            continue;
+                        }
+
+                        // Texture / derivative ops produce per-thread
+                        // values regardless of their operand uniformity.
+                        if is_per_thread_op(instr.class.opcode) {
+                            non_uniform.insert(result_id);
+                            changed = true;
+                            continue;
+                        }
+
+                        // OpLoad: result is non-uniform iff the pointer
+                        // is (which captures the OpStore propagation
+                        // we did above for local variables).
+                        if instr.class.opcode == Op::Load {
+                            if let Some(Operand::IdRef(ptr)) = instr.operands.first() {
+                                if non_uniform.contains(ptr)
+                                    || root_variable(*ptr, module)
+                                        .is_some_and(|r| non_uniform.contains(&r))
+                                {
+                                    non_uniform.insert(result_id);
+                                    changed = true;
+                                }
+                            }
+                            continue;
+                        }
+
+                        // OpAccessChain: derived pointer inherits the
+                        // base's status, but also becomes non-uniform if
+                        // any of the index operands are.
+                        if matches!(
+                            instr.class.opcode,
+                            Op::AccessChain
+                                | Op::InBoundsAccessChain
+                                | Op::PtrAccessChain
+                                | Op::InBoundsPtrAccessChain
+                        ) {
+                            let mut nu = false;
+                            for op in &instr.operands {
+                                if let Operand::IdRef(id) = op {
+                                    if non_uniform.contains(id) {
+                                        nu = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if nu {
+                                non_uniform.insert(result_id);
+                                changed = true;
+                            }
+                            continue;
+                        }
+
+                        // OpPhi: non-uniform iff any incoming value is.
+                        if instr.class.opcode == Op::Phi {
+                            // Operands alternate IdRef(value), IdRef(label).
+                            let mut nu = false;
+                            for chunk in instr.operands.chunks(2) {
+                                if let Some(Operand::IdRef(v)) = chunk.first() {
+                                    if non_uniform.contains(v) {
+                                        nu = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if nu {
+                                non_uniform.insert(result_id);
+                                changed = true;
+                            }
+                            continue;
+                        }
+
+                        // Generic: result is non-uniform iff any IdRef
+                        // operand is non-uniform.
+                        for op in &instr.operands {
+                            if let Operand::IdRef(id) = op {
+                                if non_uniform.contains(id) {
+                                    non_uniform.insert(result_id);
+                                    changed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+        }
+
+        non_uniform
+    }
+
+    /// For every `OpLoopMerge`, check whether the loop's termination
+    /// condition is non-uniform. If so, BFS the loop body (header to
+    /// continue, stopping at merge) and add every block to the result
+    /// set. Uniform loops are skipped entirely.
+    fn collect_in_nonuniform_loop_blocks(&self, non_uniform: &FxHashSet<Word>) -> FxHashSet<Word> {
+        let mut in_loop: FxHashSet<Word> = FxHashSet::default();
+
+        for function in &self.builder.module_ref().functions {
+            let mut label_to_idx: FxHashMap<Word, usize> = FxHashMap::default();
+            for (bi, block) in function.blocks.iter().enumerate() {
+                if let Some(id) = block.label_id() {
+                    label_to_idx.insert(id, bi);
+                }
+            }
+
+            for block in &function.blocks {
+                let Some(header_id) = block.label_id() else {
+                    continue;
+                };
+                let Some(loop_merge) = block
+                    .instructions
+                    .iter()
+                    .find(|i| i.class.opcode == Op::LoopMerge)
+                else {
+                    continue;
+                };
+                let Some(Operand::IdRef(merge_id)) = loop_merge.operands.first().cloned() else {
+                    continue;
+                };
+
+                // Pull the iteration condition out of the header (or the
+                // first non-trivial successor, since SPIRV-Cross often
+                // emits `header -> test -> body/merge` for `for`/`while`).
+                if !loop_condition_is_non_uniform(function, block, merge_id, non_uniform) {
+                    continue;
+                }
+
+                // BFS body, treating merge_id as a sink.
+                let mut stack: Vec<Word> = vec![header_id];
+                while let Some(label) = stack.pop() {
+                    if label == merge_id {
+                        continue;
+                    }
+                    if !in_loop.insert(label) {
+                        continue;
+                    }
+                    let Some(&idx) = label_to_idx.get(&label) else {
+                        continue;
+                    };
+                    let succ_block = &function.blocks[idx];
+                    for succ in successor_labels(succ_block) {
+                        if succ != merge_id {
+                            stack.push(succ);
+                        }
+                    }
+                }
+            }
+        }
+
+        in_loop
+    }
+
+    fn find_or_make_float_type(&mut self) -> Word {
+        for instr in &self.builder.module_ref().types_global_values {
+            if instr.class.opcode != Op::TypeFloat {
+                continue;
+            }
+            if let Some(Operand::LiteralBit32(32)) = instr.operands.first() {
+                if let Some(id) = instr.result_id {
+                    return id;
+                }
+            }
+        }
+        self.builder.type_float(32)
+    }
+}
+
+/// Resolve a pointer SSA id back to the `OpVariable` it ultimately points
+/// at, walking through `OpAccessChain` family ops. Returns `None` for
+/// pointers we can't trace (e.g. function parameters, dynamically computed
+/// pointers, etc.).
+fn root_variable(mut id: Word, module: &rspirv::dr::Module) -> Option<Word> {
+    // Bound iterations to defend against cycles in malformed modules.
+    for _ in 0..32 {
+        // Top-level OpVariable lives in `types_global_values`.
+        if module
+            .types_global_values
+            .iter()
+            .any(|i| i.result_id == Some(id) && i.class.opcode == Op::Variable)
+        {
+            return Some(id);
+        }
+        // Function-local OpVariable lives at the head of a function's first block.
+        let mut found: Option<&Instruction> = None;
+        for function in &module.functions {
+            for block in &function.blocks {
+                for instr in &block.instructions {
+                    if instr.result_id == Some(id) {
+                        found = Some(instr);
+                        break;
+                    }
+                }
+                if found.is_some() {
+                    break;
+                }
+            }
+            if found.is_some() {
+                break;
+            }
+        }
+        let instr = found?;
+        if instr.class.opcode == Op::Variable {
+            return Some(id);
+        }
+        if matches!(
+            instr.class.opcode,
+            Op::AccessChain
+                | Op::InBoundsAccessChain
+                | Op::PtrAccessChain
+                | Op::InBoundsPtrAccessChain
+                | Op::CopyObject
+        ) {
+            let Some(Operand::IdRef(base)) = instr.operands.first() else {
+                return None;
+            };
+            id = *base;
+            continue;
+        }
+        return None;
+    }
+    None
+}
+
+/// Determine whether the loop opened by `OpLoopMerge` in `header_block`
+/// has a non-uniform termination condition. We trace the conditional
+/// branch (`OpBranchConditional` or `OpSwitch`) terminating the header
+/// or its single fall-through successor.
+fn loop_condition_is_non_uniform(
+    function: &Function,
+    header_block: &rspirv::dr::Block,
+    merge_id: Word,
+    non_uniform: &FxHashSet<Word>,
+) -> bool {
+    // Candidates for the block that holds the iteration test: the header
+    // itself, or — if the header just branches unconditionally — the
+    // single successor (the typical `for`-loop shape SPIRV-Cross emits).
+    let mut candidates: Vec<&rspirv::dr::Block> = Vec::with_capacity(2);
+    candidates.push(header_block);
+    if let Some(term) = header_block.instructions.last() {
+        if term.class.opcode == Op::Branch {
+            if let Some(Operand::IdRef(t)) = term.operands.first() {
+                if let Some(target) = function.blocks.iter().find(|b| b.label_id() == Some(*t)) {
+                    candidates.push(target);
+                }
+            }
+        }
+    }
+
+    for candidate in candidates {
+        let Some(term) = candidate.instructions.last() else {
+            continue;
+        };
+        match term.class.opcode {
+            Op::BranchConditional => {
+                // Only treat this as the loop's exit test if one of the
+                // targets is the merge block — otherwise it's a nested
+                // `if` inside the loop body, which doesn't drive the
+                // iteration count.
+                let mut targets = term.operands.iter().filter_map(|o| {
+                    if let Operand::IdRef(t) = o {
+                        Some(*t)
+                    } else {
+                        None
+                    }
+                });
+                let cond = targets.next();
+                let exits_loop = targets.any(|t| t == merge_id);
+                if !exits_loop {
+                    continue;
+                }
+                if let Some(cond_id) = cond {
+                    if non_uniform.contains(&cond_id) {
+                        return true;
+                    }
+                }
+            }
+            Op::Switch => {
+                // Switch selector is the first IdRef operand.
+                let mut targets_after_default = term.operands.iter().skip(2).filter_map(|o| {
+                    if let Operand::IdRef(t) = o {
+                        Some(*t)
+                    } else {
+                        None
+                    }
+                });
+                let exits_loop = targets_after_default.any(|t| t == merge_id);
+                if !exits_loop {
+                    continue;
+                }
+                if let Some(Operand::IdRef(sel)) = term.operands.first() {
+                    if non_uniform.contains(sel) {
+                        return true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+/// Collect the labels of all successor blocks of `block` from its terminator.
+fn successor_labels(block: &rspirv::dr::Block) -> Vec<Word> {
+    let mut out = Vec::new();
+    let Some(term) = block.instructions.last() else {
+        return out;
+    };
+    match term.class.opcode {
+        Op::Branch => {
+            if let Some(Operand::IdRef(t)) = term.operands.first() {
+                out.push(*t);
+            }
+        }
+        Op::BranchConditional => {
+            for operand in term.operands.iter().take(3).skip(1) {
+                if let Operand::IdRef(t) = operand {
+                    out.push(*t);
+                }
+            }
+        }
+        Op::Switch => {
+            for op in &term.operands {
+                if let Operand::IdRef(t) = op {
+                    out.push(*t);
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Whether `instr` is an implicit-LOD sample whose existing image-operands
+/// (if any) are all compatible with rewriting to ExplicitLod with LOD 0.
+/// We refuse to touch samples that already carry `Bias` (incompatible
+/// with ExplicitLod) or `Lod`/`Grad` (already explicit).
+fn is_lowerable_implicit_sample(instr: &Instruction) -> bool {
+    match instr.class.opcode {
+        Op::ImageSampleImplicitLod | Op::ImageSparseSampleImplicitLod => {}
+        _ => return false,
+    }
+    if let Some(Operand::ImageOperands(existing)) = instr.operands.get(2) {
+        if existing.contains(ImageOperands::BIAS)
+            || existing.contains(ImageOperands::LOD)
+            || existing.contains(ImageOperands::GRAD)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// Op codes whose result is treated as non-uniform regardless of operand
+/// uniformity (texture reads, derivatives, fragment-stage helpers).
+fn is_per_thread_op(op: Op) -> bool {
+    matches!(
+        op,
+        Op::ImageSampleImplicitLod
+            | Op::ImageSampleExplicitLod
+            | Op::ImageSampleDrefImplicitLod
+            | Op::ImageSampleDrefExplicitLod
+            | Op::ImageSampleProjImplicitLod
+            | Op::ImageSampleProjExplicitLod
+            | Op::ImageSampleProjDrefImplicitLod
+            | Op::ImageSampleProjDrefExplicitLod
+            | Op::ImageRead
+            | Op::ImageFetch
+            | Op::ImageGather
+            | Op::ImageDrefGather
+            | Op::ImageSparseSampleImplicitLod
+            | Op::ImageSparseSampleExplicitLod
+            | Op::ImageSparseSampleDrefImplicitLod
+            | Op::ImageSparseSampleDrefExplicitLod
+            | Op::ImageSparseRead
+            | Op::ImageSparseFetch
+            | Op::ImageSparseGather
+            | Op::ImageSparseDrefGather
+            | Op::DPdx
+            | Op::DPdy
+            | Op::DPdxFine
+            | Op::DPdyFine
+            | Op::DPdxCoarse
+            | Op::DPdyCoarse
+            | Op::Fwidth
+            | Op::FwidthFine
+            | Op::FwidthCoarse
+    )
+}
+
+/// Convert an OpImageSampleImplicitLod (or sparse variant) into the
+/// corresponding ExplicitLod with `Lod = lod_zero`. Preserves any other
+/// image operands (e.g. ConstOffset) that came along on the original.
+fn convert_implicit_to_explicit(instr: &mut Instruction, lod_zero: Word) {
+    match instr.class.opcode {
+        Op::ImageSampleImplicitLod => {
+            instr.class = rspirv::grammar::CoreInstructionTable::get(Op::ImageSampleExplicitLod);
+        }
+        Op::ImageSparseSampleImplicitLod => {
+            instr.class =
+                rspirv::grammar::CoreInstructionTable::get(Op::ImageSparseSampleExplicitLod);
+        }
+        _ => return,
+    }
+
+    let lod_bit = ImageOperands::LOD;
+    if let Some(Operand::ImageOperands(mask)) = instr.operands.get_mut(2) {
+        *mask |= lod_bit;
+        instr.operands.insert(3, Operand::IdRef(lod_zero));
+    } else {
+        instr.operands.push(Operand::ImageOperands(lod_bit));
+        instr.operands.push(Operand::IdRef(lod_zero));
+    }
+}

--- a/librashader-reflect/src/front/spirv_passes/lower_samplers.rs
+++ b/librashader-reflect/src/front/spirv_passes/lower_samplers.rs
@@ -425,7 +425,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
 
                     // load the sampler
                     instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::Load),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::Load),
                         result_type: Some(op_type_sampler),
                         result_id: Some(op_load_sampler_id),
                         operands: vec![Operand::IdRef(combined_image_sampler.sampler_variable)],
@@ -433,7 +433,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
 
                     // reuse the old id for the OpSampleImage
                     instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::SampledImage),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::SampledImage),
                         result_type: combined_image_sampler.original_uniform_type.result_id,
                         result_id: instr.result_id,
 
@@ -602,7 +602,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
 
                     // load the sampler
                     instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::AccessChain),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::AccessChain),
                         result_type: Some(op_type_sampler_pointer),
                         result_id: Some(op_access_chain_sampler_id),
                         operands: vec![
@@ -612,7 +612,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
                     });
 
                     instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::Load),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::Load),
                         result_type: Some(op_type_sampler),
                         result_id: Some(op_load_sampler_id),
                         operands: vec![Operand::IdRef(op_access_chain_sampler_id)],
@@ -620,7 +620,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
 
                     // reuse the old id for the OpSampleImage
                     instructions.push(Instruction {
-                        class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::SampledImage),
+                        class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::SampledImage),
                         result_type: Some(op_type_sampled_image),
                         result_id: instr.result_id,
 
@@ -771,7 +771,7 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
                         let op_access_chain_sampler_id = self.builder.id();
                         // access chain the sampler
                         instructions.push(Instruction {
-                            class: rspirv::grammar::CoreInstructionTable::get(
+                            class: rspirv::grammar::INSTRUCTION_TABLE.get(
                                 spirv::Op::AccessChain,
                             ),
                             result_type: Some(op_type_sampler_pointer),
@@ -915,14 +915,14 @@ impl<'a> LowerCombinedImageSamplerPass<'a> {
                 let op_function_parameter_sampler_id = self.builder.id();
 
                 parameters.push(Instruction {
-                    class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::FunctionParameter),
+                    class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::FunctionParameter),
                     result_type: Some(sampled_image.target_texture_pointer_type_id),
                     result_id: param.result_id,
                     operands: vec![],
                 });
 
                 parameters.push(Instruction {
-                    class: rspirv::grammar::CoreInstructionTable::get(spirv::Op::FunctionParameter),
+                    class: rspirv::grammar::INSTRUCTION_TABLE.get(spirv::Op::FunctionParameter),
                     result_type: Some(sampled_image.sampler_pointer_type),
                     result_id: Some(op_function_parameter_sampler_id),
                     operands: vec![],

--- a/librashader-reflect/src/front/spirv_passes/mod.rs
+++ b/librashader-reflect/src/front/spirv_passes/mod.rs
@@ -1,3 +1,4 @@
+pub mod harden_normalize;
 pub mod link_input_outputs;
 pub mod lower_samplers;
 

--- a/librashader-reflect/src/front/spirv_passes/mod.rs
+++ b/librashader-reflect/src/front/spirv_passes/mod.rs
@@ -1,5 +1,6 @@
 pub mod harden_normalize;
 pub mod link_input_outputs;
+pub mod lower_loop_sample_lod;
 pub mod lower_samplers;
 
 // Load SPIR-V as an rspirv module

--- a/librashader-reflect/src/reflect/cross/glsl.rs
+++ b/librashader-reflect/src/reflect/cross/glsl.rs
@@ -145,7 +145,14 @@ impl CompileShader<GLSL> for CrossReflect<targets::Glsl> {
             )?;
             self.fragment
                 .set_decoration(res.id, Decoration::Binding, DecorationValue::unset())?;
-            let name = res.name.to_string();
+
+            // The SPIR-V name may collide with a GLSL reserved keyword (e.g. `noise1`,
+            // `texture2D`), in which case spirv-cross would prefix it with `_` in the
+            // emitted GLSL. That breaks the later `glGetUniformLocation` lookup which
+            // uses this name verbatim. Prefix with `LIBRA_TEXTURE_` so the identifier
+            // won't collide with any reserved words.
+            let name = format!("LIBRA_TEXTURE_{}", res.name);
+            self.fragment.set_name(res.id, name.as_str())?;
             texture_fixups.push((name, binding));
         }
 

--- a/librashader-reflect/src/reflect/cross/glsl.rs
+++ b/librashader-reflect/src/reflect/cross/glsl.rs
@@ -30,17 +30,29 @@ impl CompileShader<GLSL> for CrossReflect<targets::Glsl> {
         let vertex_resources = self.vertex.shader_resources()?;
         let fragment_resources = self.fragment.shader_resources()?;
 
+        // Vertex outputs and fragment inputs link by name once the explicit
+        // `layout(location = N)` decoration is stripped. Shaders are free to give
+        // them different identifiers (e.g. `vTexCoord_out` / `vTexCoord_in`),
+        // which links fine in Vulkan via the location but fails in GL with
+        // "not declared as an output from the previous stage". Rename both sides
+        // to `LIBRA_VARYING_{location}` so they always match.
         for res in vertex_resources.resources_for_type(ResourceType::StageOutput)? {
-            // let location = self.vertex.get_decoration(res.id, Decoration::Location)?;
-            // self.vertex
-            //     .set_name(res.id, &format!("LIBRA_VARYING_{location}"))?;
+            if let Some(DecorationValue::Literal(location)) =
+                self.vertex.decoration(res.id, Decoration::Location)?
+            {
+                self.vertex
+                    .set_name(res.id, format!("LIBRA_VARYING_{location}").as_str())?;
+            }
             self.vertex
                 .set_decoration(res.id, Decoration::Location, DecorationValue::unset())?;
         }
         for res in fragment_resources.resources_for_type(ResourceType::StageInput)? {
-            // let location = self.fragment.get_decoration(res.id, Decoration::Location)?;
-            // self.fragment
-            //     .set_name(res.id, &format!("LIBRA_VARYING_{location}"))?;
+            if let Some(DecorationValue::Literal(location)) =
+                self.fragment.decoration(res.id, Decoration::Location)?
+            {
+                self.fragment
+                    .set_name(res.id, format!("LIBRA_VARYING_{location}").as_str())?;
+            }
             self.fragment
                 .set_decoration(res.id, Decoration::Location, DecorationValue::unset())?;
         }

--- a/librashader-reflect/src/reflect/cross/hlsl.rs
+++ b/librashader-reflect/src/reflect/cross/hlsl.rs
@@ -4,6 +4,7 @@ use crate::back::{CompileShader, ShaderCompilerOutput};
 use crate::error::{ShaderCompileError, ShaderReflectError};
 use crate::front::spirv_passes::harden_normalize::HardenNormalize;
 use crate::front::spirv_passes::load_module;
+use crate::front::spirv_passes::lower_loop_sample_lod::LowerLoopSampleLod;
 use crate::front::SpirvCompilation;
 use crate::reflect::cross::{CompiledProgram, CrossReflect};
 use crate::reflect::semantics::{ShaderReflection, ShaderSemantics};
@@ -65,28 +66,49 @@ impl CompileShader<HLSL> for HlslCompileShader {
         self,
         options: Self::Options,
     ) -> Result<ShaderCompilerOutput<String, CrossHlslContext>, ShaderCompileError> {
+        // Do some unholy patching to get some shaders to work on certain DirectX shader models.
+
         let sm = options.unwrap_or(HlslShaderModel::ShaderModel5_0);
 
-        // Path to work around FXC bugs in shader model 3.0
-        if sm == HlslShaderModel::ShaderModel3_0 {
-            // Re-parse with hardened SPIR-V so spirv-cross emits HLSL that
-            // can't be folded into a NaN constant during FXC compilation.
-            let harden = |words: &[u32]| {
-                let mut builder = Builder::new_from_module(load_module(words));
-                HardenNormalize::new(&mut builder).do_pass();
-                builder.module().assemble()
+        let lowering_passes = match sm {
+            HlslShaderModel::ShaderModel3_0 => {
+                static SM3_0_LOWER: fn(&mut Builder) = |builder: &mut Builder| {
+                    HardenNormalize::new(builder).do_pass();
+                    LowerLoopSampleLod::new(builder).do_pass();
+                };
+                Some(SM3_0_LOWER)
+            }
+            HlslShaderModel::ShaderModel4_0
+            | HlslShaderModel::ShaderModel4_1
+            | HlslShaderModel::ShaderModel5_0
+            | HlslShaderModel::ShaderModel5_1 => {
+                static SM4_0_LOWER: fn(&mut Builder) = |builder: &mut Builder| {
+                    LowerLoopSampleLod::new(builder).do_pass();
+                };
+                Some(SM4_0_LOWER)
+            }
+            _ => None,
+        };
+
+        fn rewrite(words: &[u32], lowering_passes: fn(&mut Builder)) -> Vec<u32> {
+            let mut builder = Builder::new_from_module(load_module(words));
+            lowering_passes(&mut builder);
+            builder.module().assemble()
+        }
+
+        if let Some(lowering_passes) = lowering_passes {
+            let rewritten = SpirvCompilation {
+                vertex: rewrite(&self.spirv.vertex, lowering_passes),
+                fragment: rewrite(&self.spirv.fragment, lowering_passes),
             };
-            let hardened = SpirvCompilation {
-                vertex: harden(&self.spirv.vertex),
-                fragment: harden(&self.spirv.fragment),
-            };
-            let backend = HlslReflect::try_from(&hardened).map_err(|e| match e {
+
+            let backend = HlslReflect::try_from(&rewritten).map_err(|e| match e {
                 ShaderReflectError::SpirvCrossError(e) => {
                     ShaderCompileError::SpirvCrossCompileError(e)
                 }
-                e => ShaderCompileError::SpirvCrossCompileError(
-                    SpirvCrossError::InvalidArgument(e.to_string()),
-                ),
+                e => ShaderCompileError::SpirvCrossCompileError(SpirvCrossError::InvalidArgument(
+                    e.to_string(),
+                )),
             })?;
             return backend.compile(options);
         }
@@ -114,8 +136,6 @@ impl CompileShader<HLSL> for CrossReflect<targets::Hlsl> {
 
         let mut options = targets::Hlsl::options();
         options.shader_model = sm;
-
-        // todo: options
 
         let vertex_resources = self.vertex.shader_resources()?;
         let fragment_resources = self.fragment.shader_resources()?;

--- a/librashader-reflect/src/reflect/cross/hlsl.rs
+++ b/librashader-reflect/src/reflect/cross/hlsl.rs
@@ -1,8 +1,15 @@
 use crate::back::hlsl::{CrossHlslContext, HlslBufferAssignment, HlslBufferAssignments};
 use crate::back::targets::HLSL;
 use crate::back::{CompileShader, ShaderCompilerOutput};
-use crate::error::ShaderCompileError;
+use crate::error::{ShaderCompileError, ShaderReflectError};
+use crate::front::spirv_passes::harden_normalize::HardenNormalize;
+use crate::front::spirv_passes::load_module;
+use crate::front::SpirvCompilation;
 use crate::reflect::cross::{CompiledProgram, CrossReflect};
+use crate::reflect::semantics::{ShaderReflection, ShaderSemantics};
+use crate::reflect::ReflectShader;
+use rspirv::binary::Assemble;
+use rspirv::dr::Builder;
 use spirv::Decoration;
 
 use spirv_cross2::compile::hlsl::HlslShaderModel;
@@ -11,6 +18,89 @@ use spirv_cross2::reflect::{DecorationValue, ResourceType};
 use spirv_cross2::{targets, SpirvCrossError};
 
 pub(crate) type HlslReflect = CrossReflect<targets::Hlsl>;
+
+/// Wraps `HlslReflect` so we can defer the choice of shader model until
+/// `compile()` time and re-build the spirv-cross compiler from a hardened
+/// SPIR-V module when SM3 is targeted.
+///
+/// FXC SM3 rejects NaN/Inf constants that its own folder can synthesize from
+/// idioms like `normalize((0,0))`. The fix lives in
+/// `spirv_passes::harden_normalize`; we only pay the cost when actually
+/// targeting SM3, keeping the cached SPIR-V (and the reflection used by
+/// SM5+ targets) untouched.
+pub(crate) struct HlslCompileShader {
+    backend: HlslReflect,
+    spirv: SpirvCompilation,
+}
+
+impl HlslCompileShader {
+    pub(crate) fn new(spirv: SpirvCompilation) -> Result<Self, ShaderReflectError> {
+        let backend = HlslReflect::try_from(&spirv)?;
+        Ok(Self { backend, spirv })
+    }
+}
+
+impl ReflectShader for HlslCompileShader {
+    fn reflect(
+        &mut self,
+        pass_number: usize,
+        semantics: &ShaderSemantics,
+    ) -> Result<ShaderReflection, ShaderReflectError> {
+        // The hardening pass only adds an OpFAdd before each Normalize; it
+        // doesn't add/remove resources, interfaces, or semantics. Reflecting
+        // against the un-hardened module yields the same result.
+        self.backend.reflect(pass_number, semantics)
+    }
+
+    fn validate(&mut self) -> Result<(), ShaderReflectError> {
+        self.backend.validate()
+    }
+}
+
+impl CompileShader<HLSL> for HlslCompileShader {
+    type Options = Option<HlslShaderModel>;
+    type Context = CrossHlslContext;
+
+    fn compile(
+        self,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, CrossHlslContext>, ShaderCompileError> {
+        let sm = options.unwrap_or(HlslShaderModel::ShaderModel5_0);
+
+        // Path to work around FXC bugs in shader model 3.0
+        if sm == HlslShaderModel::ShaderModel3_0 {
+            // Re-parse with hardened SPIR-V so spirv-cross emits HLSL that
+            // can't be folded into a NaN constant during FXC compilation.
+            let harden = |words: &[u32]| {
+                let mut builder = Builder::new_from_module(load_module(words));
+                HardenNormalize::new(&mut builder).do_pass();
+                builder.module().assemble()
+            };
+            let hardened = SpirvCompilation {
+                vertex: harden(&self.spirv.vertex),
+                fragment: harden(&self.spirv.fragment),
+            };
+            let backend = HlslReflect::try_from(&hardened).map_err(|e| match e {
+                ShaderReflectError::SpirvCrossError(e) => {
+                    ShaderCompileError::SpirvCrossCompileError(e)
+                }
+                e => ShaderCompileError::SpirvCrossCompileError(
+                    SpirvCrossError::InvalidArgument(e.to_string()),
+                ),
+            })?;
+            return backend.compile(options);
+        }
+
+        self.backend.compile(options)
+    }
+
+    fn compile_boxed(
+        self: Box<Self>,
+        options: Self::Options,
+    ) -> Result<ShaderCompilerOutput<String, Self::Context>, ShaderCompileError> {
+        <Self as CompileShader<HLSL>>::compile(*self, options)
+    }
+}
 
 impl CompileShader<HLSL> for CrossReflect<targets::Hlsl> {
     type Options = Option<HlslShaderModel>;

--- a/librashader-runtime-d3d11/src/error.rs
+++ b/librashader-runtime-d3d11/src/error.rs
@@ -14,6 +14,8 @@ pub enum FilterChainError {
     Direct3DOperationError(&'static str),
     #[error("direct3d driver error")]
     Direct3DError(#[from] windows::core::Error),
+    #[error("d3d11 could not compile shader: {0}")]
+    D3DCompileError(String),
     #[error("shader preset parse error")]
     ShaderPresetError(#[from] ParsePresetError),
     #[error("shader preprocess error")]

--- a/librashader-runtime-d3d11/src/util.rs
+++ b/librashader-runtime-d3d11/src/util.rs
@@ -112,7 +112,8 @@ pub fn d3d11_get_closest_format(
 pub fn d3d_compile_shader(source: &[u8], entry: &[u8], version: &[u8]) -> error::Result<ID3DBlob> {
     unsafe {
         let mut blob = None;
-        D3DCompile(
+        let mut error_blob = None;
+        let result = D3DCompile(
             source.as_ptr().cast(),
             source.len(),
             None,
@@ -127,8 +128,21 @@ pub fn d3d_compile_shader(source: &[u8], entry: &[u8], version: &[u8]) -> error:
             },
             0,
             &mut blob,
-            None,
-        )?;
+            Some(&mut error_blob),
+        );
+
+        if let Err(e) = result {
+            if let Some(eb) = error_blob {
+                let ptr = eb.GetBufferPointer() as *const u8;
+                let len = eb.GetBufferSize();
+                let bytes = std::slice::from_raw_parts(ptr, len);
+                // D3DCompile error blobs are NUL-terminated ASCII; strip the trailing NUL if present.
+                let bytes = bytes.strip_suffix(b"\0").unwrap_or(bytes);
+                let msg = String::from_utf8_lossy(bytes).into_owned();
+                return Err(crate::error::FilterChainError::D3DCompileError(msg));
+            }
+            return Err(e.into());
+        }
 
         assume_d3d11_init!(blob, "D3DCompile");
         Ok(blob)

--- a/librashader-runtime-d3d11/tests/triangle.rs
+++ b/librashader-runtime-d3d11/tests/triangle.rs
@@ -12,13 +12,13 @@ use librashader_runtime_d3d11::options::FilterChainOptionsD3D11;
 // const FILTER_PATH: &str =
 //     "../test/Mega_Bezel_Packs/Duimon-Mega-Bezel/Presets/Advanced/Nintendo_GBA_SP/GBA_SP-[ADV]-[LCD-GRID].slangp";
 
-// const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-royale.slangp";
+const FILTER_PATH: &str = "../test/shaders_slang/crt/crt-royale.slangp";
 
 // const FILTER_PATH: &str = "../test/slang-shaders/test/history.slangp";
 // const FILTER_PATH: &str = "../test/shaders_slang/test/feedback.slangp";
 
 // const FILTER_PATH: &str = "../test/aspect.slangp";
-const FILTER_PATH: &str = "../test/shaders_slang/sonkun/slot-mask/flat-screen/1080p/test.slangp";
+// const FILTER_PATH: &str = "../test/shaders_slang/sonkun/slot-mask/flat-screen/1080p/test.slangp";
 
 const IMAGE_PATH: &str = "../triangle.png";
 #[test]
@@ -43,13 +43,7 @@ fn triangle_d3d11_args() {
         Some(image),
     )
     .unwrap();
-    // let sample = hello_triangle_old::d3d11_hello_triangle::Sample::new(
-    //     "../test/slang-shaders/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
-    //     Some(&FilterChainOptions {
-    //         use_deferred_context: true,
-    //     })
-    // )
-    // .unwrap();
+
 
     // let sample = hello_triangle_old::d3d11_hello_triangle::Sample::new("../test/basic.slangp").unwrap();
 
@@ -59,10 +53,10 @@ fn triangle_d3d11_args() {
 #[test]
 fn triangle_d3d11() {
     let sample = hello_triangle::d3d11_hello_triangle::Sample::new(
-        FILTER_PATH,
+        "../test/shaders_slang/bezel/Mega_Bezel/Presets/MBZ__0__SMOOTH-ADV.slangp",
         Some(&FilterChainOptionsD3D11 {
             force_no_mipmaps: false,
-            disable_cache: true,
+            disable_cache: false,
         }),
         // replace below with 'None' for the triangle
         None,

--- a/librashader-runtime-d3d11/tests/triangle.rs
+++ b/librashader-runtime-d3d11/tests/triangle.rs
@@ -44,7 +44,6 @@ fn triangle_d3d11_args() {
     )
     .unwrap();
 
-
     // let sample = hello_triangle_old::d3d11_hello_triangle::Sample::new("../test/basic.slangp").unwrap();
 
     hello_triangle::main(sample).unwrap();

--- a/librashader-runtime-d3d12/src/filter_chain.rs
+++ b/librashader-runtime-d3d12/src/filter_chain.rs
@@ -1,5 +1,5 @@
 use crate::buffer::{D3D12Buffer, RawD3D12Buffer};
-use crate::descriptor_heap::{CpuStagingHeap, RenderTargetHeap, ResourceWorkHeap};
+use crate::descriptor_heap::{CpuStagingHeap, RenderTargetHeap, ResourceWorkHeap, SamplerWorkHeap};
 use crate::draw_quad::DrawQuad;
 use crate::error::FilterChainError;
 use crate::filter_pass::FilterPass;
@@ -89,6 +89,7 @@ pub(crate) struct FilterCommon {
     pub feedback_textures: Box<[Option<InputTexture>]>,
     pub history_textures: Box<[Option<InputTexture>]>,
     pub config: RuntimeParameters,
+    pub internal_frame_count: usize,
     // pub disable_mipmaps: bool,
     pub luts: FastHashMap<usize, LutTexture>,
     pub mipmap_gen: D3D12MipmapGen,
@@ -339,6 +340,11 @@ impl FilterChainD3D12 {
         cmd: &ID3D12GraphicsCommandList,
         options: Option<&FilterChainOptionsD3D12>,
     ) -> error::Result<FilterChainD3D12> {
+        let mut frames_in_flight = options.map_or(0, |o| o.frames_in_flight);
+        if frames_in_flight == 0 {
+            frames_in_flight = 3;
+        }
+
         let config = RuntimeParameters::new(&preset);
 
         let shader_count = preset.passes.len();
@@ -390,6 +396,7 @@ impl FilterChainD3D12 {
             &semantics,
             options.map_or(false, |o| o.force_hlsl_pipeline),
             disable_cache,
+            frames_in_flight as usize,
         )?;
 
         let mut residuals = FrameResiduals::new();
@@ -444,6 +451,7 @@ impl FilterChainD3D12 {
                 draw_quad,
                 config,
                 history_textures,
+                internal_frame_count: 0,
             },
             staging_heap,
             rtv_heap,
@@ -521,6 +529,7 @@ impl FilterChainD3D12 {
         semantics: &ShaderSemantics,
         force_hlsl: bool,
         disable_cache: bool,
+        frames_in_flight: usize,
     ) -> error::Result<(
         ID3D12DescriptorHeap,
         ID3D12DescriptorHeap,
@@ -528,6 +537,7 @@ impl FilterChainD3D12 {
         D3D12DescriptorHeap<ResourceWorkHeap>,
     )> {
         let shader_count = passes.len();
+
         let D3D12PartitionedHeap {
             partitioned: work_heaps,
             reserved: mipmap_heap,
@@ -535,7 +545,8 @@ impl FilterChainD3D12 {
         } = unsafe {
             let work_heap = D3D12PartitionableHeap::<ResourceWorkHeap>::new(
                 device,
-                (MAX_BINDINGS_COUNT as usize) * shader_count + MIPMAP_RESERVED_WORKHEAP_DESCRIPTORS,
+                (MAX_BINDINGS_COUNT as usize) * shader_count * frames_in_flight
+                    + MIPMAP_RESERVED_WORKHEAP_DESCRIPTORS,
             )?;
 
             work_heap.into_partitioned(
@@ -549,16 +560,33 @@ impl FilterChainD3D12 {
             reserved: _,
             handle: sampler_heap_handle,
         } = unsafe {
-            let sampler_heap =
-                D3D12PartitionableHeap::new(device, (MAX_BINDINGS_COUNT as usize) * shader_count)?;
+            let sampler_heap = D3D12PartitionableHeap::new(
+                device,
+                (MAX_BINDINGS_COUNT as usize) * shader_count * frames_in_flight,
+            )?;
             sampler_heap.into_partitioned(MAX_BINDINGS_COUNT as usize, 0)?
+        };
+
+        // Group the per-pass partitions: each shader pass takes `frames_in_flight`
+        // contiguous partitions so it can rotate descriptor tables per in-flight frame.
+        let work_heap_chunks: Vec<Vec<D3D12DescriptorHeap<ResourceWorkHeap>>> = {
+            let mut iter = work_heaps.into_iter();
+            (0..shader_count)
+                .map(|_| iter.by_ref().take(frames_in_flight).collect())
+                .collect()
+        };
+        let sampler_heap_chunks: Vec<Vec<D3D12DescriptorHeap<SamplerWorkHeap>>> = {
+            let mut iter = sampler_work_heaps.into_iter();
+            (0..shader_count)
+                .map(|_| iter.by_ref().take(frames_in_flight).collect())
+                .collect()
         };
 
         let filters: Vec<error::Result<_>> = passes
             .into_par_iter()
             .zip(hlsl_passes)
-            .zip(work_heaps)
-            .zip(sampler_work_heaps)
+            .zip(work_heap_chunks)
+            .zip(sampler_heap_chunks)
             .enumerate()
             .map_init(
                 || {
@@ -571,7 +599,7 @@ impl FilterChainD3D12 {
                 |dxc,
                  (
                     index,
-                    ((((config, mut dxil), (_, mut hlsl)), mut texture_heap), mut sampler_heap),
+                    ((((config, mut dxil), (_, mut hlsl)), texture_heap_chunk), sampler_heap_chunk),
                 )| {
                     let Ok((validator, library, compiler)) = dxc else {
                         return Err(FilterChainError::Direct3DOperationError(
@@ -645,8 +673,16 @@ impl FilterChainD3D12 {
                     let uniform_bindings =
                         reflection.meta.create_binding_map(|param| param.offset());
 
-                    let texture_heap = texture_heap.allocate_descriptor_range()?;
-                    let sampler_heap = sampler_heap.allocate_descriptor_range()?;
+                    let texture_heap = texture_heap_chunk
+                        .into_iter()
+                        .map(|mut p| p.allocate_descriptor_range::<16>().map_err(Into::into))
+                        .collect::<error::Result<Vec<_>>>()?
+                        .into_boxed_slice();
+                    let sampler_heap = sampler_heap_chunk
+                        .into_iter()
+                        .map(|mut p| p.allocate_descriptor_range::<16>().map_err(Into::into))
+                        .collect::<error::Result<Vec<_>>>()?
+                        .into_boxed_slice();
 
                     Ok(FilterPass {
                         reflection,
@@ -976,6 +1012,8 @@ impl FilterChainD3D12 {
         }
 
         self.push_history(cmd, &original)?;
+
+        self.common.internal_frame_count = self.common.internal_frame_count.wrapping_add(1);
 
         Ok(())
     }

--- a/librashader-runtime-d3d12/src/filter_pass.rs
+++ b/librashader-runtime-d3d12/src/filter_pass.rs
@@ -34,8 +34,8 @@ pub(crate) struct FilterPass {
     pub(crate) uniform_bindings: FastHashMap<UniformBinding, MemberOffset>,
     pub uniform_storage:
         UniformStorage<NoUniformBinder, Option<()>, RawD3D12Buffer, RawD3D12Buffer>,
-    pub(crate) texture_heap: [D3D12DescriptorHeapSlot<ResourceWorkHeap>; 16],
-    pub(crate) sampler_heap: [D3D12DescriptorHeapSlot<SamplerWorkHeap>; 16],
+    pub(crate) texture_heap: Box<[[D3D12DescriptorHeapSlot<ResourceWorkHeap>; 16]]>,
+    pub(crate) sampler_heap: Box<[[D3D12DescriptorHeapSlot<SamplerWorkHeap>; 16]]>,
     pub source: ShaderSource,
 }
 
@@ -96,11 +96,15 @@ impl FilterPass {
         original: &InputTexture,
         source: &InputTexture,
     ) {
+        let frame_idx = parent.internal_frame_count % self.texture_heap.len();
         Self::bind_semantics(
             &(),
             &parent.samplers,
             &mut self.uniform_storage,
-            &mut (&mut self.texture_heap, &mut self.sampler_heap),
+            &mut (
+                &mut self.texture_heap[frame_idx],
+                &mut self.sampler_heap[frame_idx],
+            ),
             UniformInputs {
                 mvp,
                 frame_count,
@@ -151,6 +155,9 @@ impl FilterPass {
             cmd.SetPipelineState(self.pipeline.pipeline_state(output.output.format));
         }
 
+        // texture and sampler heap must have the same size.
+        let frame_idx = parent.internal_frame_count % self.texture_heap.len();
+
         self.build_semantics(
             pass_index,
             parent,
@@ -182,8 +189,8 @@ impl FilterPass {
         }
 
         unsafe {
-            cmd.SetGraphicsRootDescriptorTable(0, *self.texture_heap[0].as_ref());
-            cmd.SetGraphicsRootDescriptorTable(1, *self.sampler_heap[0].as_ref());
+            cmd.SetGraphicsRootDescriptorTable(0, *self.texture_heap[frame_idx][0].as_ref());
+            cmd.SetGraphicsRootDescriptorTable(1, *self.sampler_heap[frame_idx][0].as_ref());
         }
 
         // todo: check for non-renderpass.

--- a/librashader-runtime-d3d12/src/options.rs
+++ b/librashader-runtime-d3d12/src/options.rs
@@ -18,4 +18,7 @@ pub struct FilterChainOptionsD3D12 {
     /// Disable the shader object cache. Shaders will be
     /// recompiled rather than loaded from the cache.
     pub disable_cache: bool,
+
+    /// The number of frames in flight to keep. If zero, defaults to three.
+    pub frames_in_flight: u32,
 }

--- a/librashader-runtime-d3d9/src/util.rs
+++ b/librashader-runtime-d3d9/src/util.rs
@@ -150,7 +150,7 @@ pub fn d3d_compile_shader(source: &[u8], entry: &[u8], version: &[u8]) -> error:
                 Some(&mut errs),
             );
         }
-        
+
         // let res = D3DXCompileShader(
         //     source.as_ptr().cast(),
         //     source.len(),

--- a/librashader-runtime-d3d9/tests/hello_triangle/mod.rs
+++ b/librashader-runtime-d3d9/tests/hello_triangle/mod.rs
@@ -194,12 +194,12 @@ pub mod d3d9_hello_triangle {
 
     use std::path::{Path, PathBuf};
 
+    use librashader_common::shader_features::ShaderFeatures;
     use librashader_common::{GetSize, Viewport};
     use librashader_runtime::image::{Image, UVDirection, ARGB8, BGRA8, RGBA8};
     use librashader_runtime_d3d9::options::FilterChainOptionsD3D9;
     use librashader_runtime_d3d9::FilterChainD3D9;
     use std::time::Instant;
-    use librashader_common::shader_features::ShaderFeatures;
 
     pub struct Sample {
         pub direct3d: IDirect3D9,

--- a/librashader-runtime-gl/src/error.rs
+++ b/librashader-runtime-gl/src/error.rs
@@ -26,14 +26,14 @@ pub enum FilterChainError {
     LutLoadError(#[from] ImageError),
     #[error("opengl was not initialized")]
     GLLoadError,
-    #[error("opengl could not link program")]
-    GLLinkError,
-    #[error("opengl could not compile program")]
-    GlCompileError,
+    #[error("opengl could not link program: {0}")]
+    GLLinkError(String),
+    #[error("opengl could not compile program: {0}")]
+    GlCompileError(String),
     #[error("opengl could not create samplers")]
     GlSamplerError,
-    #[error("opengl could not create samplers")]
-    GlProgramError,
+    #[error("opengl could not create program: {0}")]
+    GlProgramError(String),
     #[error("an invalid framebuffer was provided to frame")]
     GlInvalidFramebuffer,
     #[error("opengl error: {0}")]

--- a/librashader-runtime-gl/src/gl/gl3/compile_program.rs
+++ b/librashader-runtime-gl/src/gl/gl3/compile_program.rs
@@ -47,7 +47,8 @@ impl CompileProgram for Gl3CompileProgram {
             ctx.delete_shader(fragment);
 
             if !ctx.get_program_link_status(program) {
-                return Err(FilterChainError::GLLinkError);
+                let log = ctx.get_program_info_log(program);
+                return Err(FilterChainError::GLLinkError(log));
             }
 
             ctx.use_program(Some(program));

--- a/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl3/framebuffer.rs
@@ -288,6 +288,9 @@ impl FramebufferInterface for Gl3Framebuffer {
                 }
             }
 
+            // Zero-initialize the texture storage.
+            Self::clear::<false>(fb);
+
             fb.ctx.bind_framebuffer(glow::FRAMEBUFFER, None);
             fb.ctx.bind_texture(glow::TEXTURE_2D, None);
         }

--- a/librashader-runtime-gl/src/gl/gl46/compile_program.rs
+++ b/librashader-runtime-gl/src/gl/gl46/compile_program.rs
@@ -25,10 +25,10 @@ impl Cacheable for GlProgramBinary {
             return None;
         };
 
-        return Some(GlProgramBinary(Some(glow::ProgramBinary {
+        Some(GlProgramBinary(Some(glow::ProgramBinary {
             buffer: cached,
             format: *format,
-        })));
+        })))
     }
 
     fn to_bytes(&self) -> Option<Vec<u8>> {
@@ -59,7 +59,7 @@ impl CompileProgram for Gl4CompileProgram {
 
                 let program = context
                     .create_program()
-                    .map_err(|_| FilterChainError::GlProgramError)?;
+                    .map_err(|e| FilterChainError::GlProgramError(e))?;
 
                 context.attach_shader(program, vertex);
                 context.attach_shader(program, fragment);
@@ -82,7 +82,8 @@ impl CompileProgram for Gl4CompileProgram {
                 context.delete_shader(fragment);
 
                 if !context.get_program_link_status(program) {
-                    return Err(FilterChainError::GLLinkError);
+                    let log = context.get_program_info_log(program);
+                    return Err(FilterChainError::GLLinkError(log));
                 }
                 Ok(program)
             }
@@ -100,7 +101,7 @@ impl CompileProgram for Gl4CompileProgram {
             |binary| unsafe {
                 let program = context
                     .create_program()
-                    .map_err(|_| FilterChainError::GlProgramError)?;
+                    .map_err(|e| FilterChainError::GlProgramError(e))?;
 
                 if let Some(binary) = &binary.0 {
                     context.program_binary(program, binary);

--- a/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
+++ b/librashader-runtime-gl/src/gl/gl46/framebuffer.rs
@@ -233,6 +233,9 @@ impl FramebufferInterface for Gl46Framebuffer {
                     _ => return Err(FilterChainError::FramebufferInit(status)),
                 }
             }
+
+            // Zero-initialize the texture storage.
+            Self::clear::<false>(fb);
         }
         Ok(())
     }

--- a/librashader-runtime-gl/src/util.rs
+++ b/librashader-runtime-gl/src/util.rs
@@ -12,14 +12,15 @@ pub fn gl_compile_shader(
     unsafe {
         let shader = context
             .create_shader(stage)
-            .map_err(|_| FilterChainError::GlCompileError)?;
+            .map_err(FilterChainError::GlCompileError)?;
 
         context.shader_source(shader, &source);
         context.compile_shader(shader);
         let compile_status = context.get_shader_compile_status(shader);
 
         if !compile_status {
-            Err(FilterChainError::GlCompileError)
+            let log = context.get_shader_info_log(shader);
+            Err(FilterChainError::GlCompileError(log))
         } else {
             Ok(shader)
         }

--- a/librashader-runtime-wgpu/src/graphics_pipeline.rs
+++ b/librashader-runtime-wgpu/src/graphics_pipeline.rs
@@ -99,7 +99,7 @@ impl PipelineLayoutObjects {
             entries: &sampler_bindings,
         });
 
-        let bind_group_layout_refs = [&main_bind_group, &sampler_bind_group];
+        let bind_group_layout_refs = [Some(&main_bind_group), Some(&sampler_bind_group)];
 
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("shader pipeline layout"),

--- a/librashader.copr.spec
+++ b/librashader.copr.spec
@@ -36,12 +36,13 @@ RUSTC_BOOTSTRAP=1 cargo run -p librashader-build-script -- --profile %{profile}
 mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_includedir}/librashader
 patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
-install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h 
-cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h 
+install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
+ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
+cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 
-%files 
+%files
 %{_libdir}/librashader.so
 %{_libdir}/librashader.so.2
 %{_includedir}/librashader/

--- a/librashader/src/lib.rs
+++ b/librashader/src/lib.rs
@@ -26,7 +26,6 @@
 //!
 //! Shader compatibility is not guaranteed on render APIs with secondary support.
 //!
-//! wgpu has restrictions on shaders that can not be converted to WGSL, such as those that use `inverse`.
 //! Direct3D 9 does not support shaders that need Direct3D 10+ only features, or shaders that can not be
 //! compiled to [Shader Model 3.0](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/shader-model-3).
 //!

--- a/pkg/librashader.spec
+++ b/pkg/librashader.spec
@@ -34,12 +34,14 @@ RUSTC_BOOTSTRAP=1 cargo run -p librashader-build-script -- --profile %{profile}
 %install
 mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_includedir}/librashader
-patchelf --set-soname librashader.so.1 target/%{profile}/librashader.so
-install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h 
-cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h 
+patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
+install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
+ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
+cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 
-%files 
+%files
 %{_libdir}/librashader.so
+%{_libdir}/librashader.so.2
 %{_includedir}/librashader/

--- a/pkg/obs/PKGBUILD
+++ b/pkg/obs/PKGBUILD
@@ -27,7 +27,8 @@ package() {
   mkdir -p $pkgdir/usr/lib
   mkdir -p $pkgdir/usr/include/librashader
   patchelf --set-soname librashader.so.2 $srcdir/$pkgname-$pkgver/target/$profile/librashader.so
-  install -m 0755 $srcdir/$pkgname-$pkgver/target/${profile}/librashader.so $pkgdir/usr/lib/librashader.so
+  install -m 0755 $srcdir/$pkgname-$pkgver/target/${profile}/librashader.so $pkgdir/usr/lib/librashader.so.2
+  ln -s librashader.so.2 $pkgdir/usr/lib/librashader.so
   cp $srcdir/$pkgname-$pkgver/target/${profile}/librashader.h $pkgdir/usr/include/librashader/librashader.h
   cp $srcdir/$pkgname-$pkgver/include/librashader_ld.h $pkgdir/usr/include/librashader/librashader_ld.h
 }

--- a/pkg/obs/librashader.spec
+++ b/pkg/obs/librashader.spec
@@ -33,14 +33,13 @@ RUSTC_BOOTSTRAP=1 cargo run --ignore-rust-version -p librashader-build-script --
 mkdir -p %{buildroot}/%{_libdir}
 mkdir -p %{buildroot}/%{_includedir}/librashader
 patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
-install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h 
-cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h 
+install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
+ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
+cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 
-%files 
+%files
 %{_libdir}/librashader.so
-%if !0%{?suse_version}
 %{_libdir}/librashader.so.2
-%endif
 %{_includedir}/librashader/


### PR DESCRIPTION
* Serialize persy cache writes (Fixes #200)
* d3d12: add frames in flight to avoid descriptor heap corruption (Fixes #201)
* gl: prefix identifiers in generated GLSL to stop hitting reserved words (Fixes #182)
* parse: default LUTs to sample linearly instead of nearest neighbour (Fixes #181)
* gl: zero FBOs on init (Fixes #204)
* d3d11,gl: output compiler errors when available
* d3d11, d3d9: lower `sample` to `sampleLod` when in a non-uniform loop
* d3d9: add epsilon to `normalize` calls to prevent it from degenerating into NaNs. This enables crt-royale on d3d9.
* wgpu: Update to wgpu 29
* deps: update glslang, rspirv, spirv_cross2
* build: fix OBS spec (Fixes #180)