### PR TITLE
build: default to stable instead of nightly Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Build dynamic library
         run: cargo run -p librashader-build-script -- --profile ${{ matrix.profile }}
+      - name: Stage C header for upload
+        shell: bash
+        run: cp include/librashader.h target/${{ matrix.profile }}/librashader.h
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.4.0
         with:
@@ -76,10 +77,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
           targets: aarch64-unknown-linux-gnu
       - name: Install ARM64 cross-compilation dependencies
         continue-on-error: true
@@ -92,6 +92,8 @@ jobs:
           sudo apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu xorg-dev libx11-dev:arm64 libxrandr-dev:arm64
       - name: Build dynamic library
         run: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc cargo run -p librashader-build-script -- --profile ${{ matrix.profile }} --target aarch64-unknown-linux-gnu
+      - name: Stage C header for upload
+        run: cp include/librashader.h target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/librashader.h
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.4.0
         with:
@@ -116,13 +118,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly
           targets: aarch64-pc-windows-msvc
       - name: Build dynamic library
         run: cargo run -p librashader-build-script -- --profile ${{ matrix.profile }} --target aarch64-pc-windows-msvc
+      - name: Stage C header for upload
+        shell: bash
+        run: cp include/librashader.h target/aarch64-pc-windows-msvc/${{ matrix.profile }}/librashader.h
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.4.0
         with:
@@ -147,6 +151,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      # Tier 3 target; -Zbuild-std requires nightly. The build itself stays on the
+      # stable code path because we do not pass --nightly to the build script.
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -154,6 +160,9 @@ jobs:
           components: rust-src
       - name: Build dynamic library
         run: cargo run -p librashader-build-script -- --profile ${{ matrix.profile }} --target x86_64-win7-windows-msvc -- -Zbuild-std
+      - name: Stage C header for upload
+        shell: bash
+        run: cp include/librashader.h target/x86_64-win7-windows-msvc/${{ matrix.profile }}/librashader.h
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4.4.0
         with:

--- a/.github/workflows/publish-obs.yml
+++ b/.github/workflows/publish-obs.yml
@@ -14,10 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
       - name: Install OSC and dependencies
         env:
           OBS_CONFIG: ${{ secrets.OBS_CONFIG }}

--- a/README.md
+++ b/README.md
@@ -143,27 +143,25 @@ While librashader has no build-time dependencies, using `librashader_ld.h` may r
 the relevant runtime graphics API.
 
 
-### Building against stable Rust
-While librashader is intended to be used with nightly Rust until [required features](https://github.com/SnowflakePowered/librashader/issues/55) are stabilized, it supports being
-built with stable Rust with the `stable` feature.
+### Building against nightly Rust
+As of librashader 0.11, building on the stable MSRV is the default behaviour.
 
-```toml 
-librashader = { features = ["stable"] }
+To opt in to minor optimizations with `impl_trait_in_assoc_type` enabled by nightly and C header generation, enable the `nightly` feature.
+
+```toml
+librashader = { version = "0.11", features = ["nightly"] }
 ```
 
-If building the C API, the `--stable` flag in the build script will enable the `stable` feature.
+When building the C API with `librashader-build-script`, to build with nightly features on, pass the `--nightly` flag 
+when using a nightly toolchain.
 
 ```
-cargo +stable run -p librashader-build-script -- --profile optimized --stable 
+cargo run -p librashader-build-script -- --profile optimized --nightly
 ```
+The `stable` feature and `--stable` flag remain for backwards compatibility but no longer do anything. 
 
-There are some caveats when building against stable Rust, such that building librashader against nightly Rust is still highly encouraged.
-
-* C headers will not be regenerated when building with the `stable` feature.
-* There is a minor performance hit in initial shader compilation when building against stable Rust. This is due to boxed trait objects being used instead of `impl Trait`.
-* A higher MSRV is required when building against stable Rust.
-
-When the `trait_alias_impl_trait` feature is stabilized, the `stable` feature will be removed. 
+Using `nightly` to generate the C headers is no longer encouraged due to `cargo expand` breaking feature flags. Please 
+use the provided `librashader.h` in the `include` folder.
 
 ## Examples
 
@@ -274,18 +272,7 @@ for migration instructions.
 
 ### MSRV Policy
 
-Building against stable Rust requires the following MSRV.
-
-* All platforms: **1.78**
-
-When building against nightly Rust, the following MSRV policy is enforced for unstable library features.
-
-* All platforms: **1.87**
-
-A CI job runs weekly to ensure librashader continues to build on nightly.
-
-Note that the MSRV is only intended to ease distribution on Linux when building against nightly Rust or with `RUSTC_BOOTSTRAP=1`, and is allowed to change any time. 
-It generally tracks the latest version of Rust available in the latest version of Ubuntu, but this may change with no warning in a patch release.
+Building against stable Rust requires Rust **1.78**. No guarantees are provided for nightly MSRVs. 
 
 ## License
 The core parts of librashader such as the preprocessor, the preset parser, 

--- a/librashader-build-script/src/main.rs
+++ b/librashader-build-script/src/main.rs
@@ -13,7 +13,13 @@ struct Args {
     profile: String,
     #[arg(long, global = true)]
     target: Option<String>,
+    /// Build with the nightly `impl_trait_in_assoc_type` code path and regenerate C headers.
+    /// Requires a nightly Rust toolchain.
     #[arg(long, default_value_t = false, global = true)]
+    nightly: bool,
+    /// Deprecated. The stable code path is the default since librashader 0.11; this flag is accepted for
+    /// backwards compatibility with existing packaging scripts and does nothing.
+    #[arg(long, default_value_t = false, global = true, hide = true)]
     stable: bool,
     #[arg(last = true)]
     cargoflags: Vec<String>,
@@ -42,20 +48,22 @@ pub fn main() -> ExitCode {
         if profile == "debug" { "dev" } else { &profile }
     ));
 
-    // If we're on RUSTC_BOOTSTRAP, it's likely because we're building for a package..
-    if env::var("RUSTC_BOOTSTRAP").is_ok() {
-        cmd.arg("--ignore-rust-version");
-    }
-
     if let Some(target) = &args.target {
         cmd.arg(format!("--target={}", &target));
     }
 
     if args.stable {
+        carlog_warning!("--stable is deprecated and does nothing; stable is now the default");
+    }
+
+    if args.nightly {
+        carlog_info!("Building", "with nightly `impl_trait_in_assoc_type` code path");
+        cmd.args(["--features", "nightly"]);
+    } else {
         carlog_warning!("building librashader with stable Rust compatibility");
         carlog_warning!("C headers will not be generated");
-        cmd.args(["--features", "stable"]);
     }
+
     if !args.cargoflags.is_empty() {
         cmd.args(args.cargoflags);
     }
@@ -82,7 +90,9 @@ pub fn main() -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    if args.stable {
+    // cbindgen's macro expansion requires a nightly toolchain; only run it when
+    // the user opts in with --nightly.
+    if !args.nightly {
         carlog_warning!("generating C headers is not supported when building for stable Rust");
     } else {
         carlog_info!("Generating", "librashader C API headers");

--- a/librashader-capi/Cargo.toml
+++ b/librashader-capi/Cargo.toml
@@ -15,7 +15,7 @@ description = "RetroArch shaders for all."
 crate-type = [ "cdylib", "staticlib" ]
 
 [features]
-default = ["runtime-all" ]
+default = ["runtime-all"]
 runtime-all = ["runtime-opengl", "runtime-d3d9", "runtime-d3d11", "runtime-d3d12", "runtime-vulkan", "runtime-metal"]
 runtime-opengl = ["glow", "librashader/runtime-gl"]
 runtime-d3d11 = ["windows", "librashader/runtime-d3d11", "windows/Win32_Graphics_Direct3D11"]
@@ -26,7 +26,9 @@ runtime-vulkan = ["ash", "librashader/runtime-vk"]
 runtime-metal = ["__cbindgen_internal_objc", "librashader/runtime-metal"]
 
 reflect-unstable = []
-stable = ["librashader/stable"]
+nightly = ["librashader/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 docsrs = []
 
 __cbindgen_internal = ["runtime-all"]

--- a/librashader-reflect/Cargo.toml
+++ b/librashader-reflect/Cargo.toml
@@ -45,6 +45,9 @@ naga = [ "dep:rspirv", "dep:spirv", "dep:naga", "naga/spv-in", "naga/spv-out", "
 serde = ["dep:serde", "serde/derive", "librashader-common/serde", "bitflags/serde"]
 msl = [ "cross", "spirv-cross2/msl", "naga?/msl-out" ]
 
+nightly = []
+# No-op alias for backwards compatibility with older consumers that opted into `stable`.
+# The stable code path is now the default; this feature is intentionally empty.
 stable = []
 
 unstable-naga-in = ["naga/glsl-in"]

--- a/librashader-reflect/src/back/dxil.rs
+++ b/librashader-reflect/src/back/dxil.rs
@@ -17,7 +17,7 @@ impl OutputTarget for DXIL {
     type Output = DxilObject;
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, SpirvCross> for DXIL {
     type Target = DXIL;
     type Options = Option<ShaderModel>;
@@ -39,7 +39,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for DXIL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for DXIL {
     type Target = DXIL;
     type Options = Option<ShaderModel>;

--- a/librashader-reflect/src/back/glsl.rs
+++ b/librashader-reflect/src/back/glsl.rs
@@ -17,7 +17,7 @@ pub struct CrossGlslContext {
     pub artifact: CompiledProgram<spirv_cross2::targets::Glsl>,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     type Target = GLSL;
     type Options = GlslVersion;
@@ -33,7 +33,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for GLSL {
     type Target = GLSL;
     type Options = GlslVersion;

--- a/librashader-reflect/src/back/hlsl.rs
+++ b/librashader-reflect/src/back/hlsl.rs
@@ -103,7 +103,7 @@ pub struct CrossHlslContext {
     pub fragment_buffers: HlslBufferAssignments,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     type Target = HLSL;
     type Options = Option<HlslShaderModel>;
@@ -119,7 +119,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for HLSL {
     type Target = HLSL;
     type Options = Option<HlslShaderModel>;

--- a/librashader-reflect/src/back/msl.rs
+++ b/librashader-reflect/src/back/msl.rs
@@ -24,7 +24,7 @@ pub struct CrossMslContext {
     pub artifact: CompiledProgram<spirv_cross2::targets::Msl>,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
@@ -40,7 +40,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
@@ -68,7 +68,7 @@ pub struct NagaMslContext {
     pub next_free_binding: u32,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, Naga> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;
@@ -84,7 +84,7 @@ impl FromCompilation<SpirvCompilation, Naga> for MSL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, Naga> for MSL {
     type Target = MSL;
     type Options = Option<self::MslVersion>;

--- a/librashader-reflect/src/back/spirv.rs
+++ b/librashader-reflect/src/back/spirv.rs
@@ -18,7 +18,7 @@ pub(crate) struct WriteSpirV {
     pub(crate) fragment: Vec<u32>,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, SpirvCross> for SPIRV {
     type Target = SPIRV;
     type Options = Option<()>;
@@ -41,7 +41,7 @@ impl FromCompilation<SpirvCompilation, SpirvCross> for SPIRV {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, SpirvCross> for SPIRV {
     type Target = SPIRV;
     type Options = Option<()>;
@@ -111,7 +111,7 @@ pub struct NagaSpirvContext {
     pub vertex: Module,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, Naga> for SPIRV {
     type Target = SPIRV;
     type Options = NagaSpirvOptions;
@@ -127,7 +127,7 @@ impl FromCompilation<SpirvCompilation, Naga> for SPIRV {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, Naga> for SPIRV {
     type Target = SPIRV;
     type Options = NagaSpirvOptions;

--- a/librashader-reflect/src/back/wgsl.rs
+++ b/librashader-reflect/src/back/wgsl.rs
@@ -11,7 +11,7 @@ pub struct NagaWgslContext {
     pub vertex: Module,
 }
 
-#[cfg(not(feature = "stable"))]
+#[cfg(feature = "nightly")]
 impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     type Target = WGSL;
     type Options = NagaLoweringOptions;
@@ -27,7 +27,7 @@ impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     }
 }
 
-#[cfg(feature = "stable")]
+#[cfg(not(feature = "nightly"))]
 impl FromCompilation<SpirvCompilation, Naga> for WGSL {
     type Target = WGSL;
     type Options = NagaLoweringOptions;

--- a/librashader-reflect/src/lib.rs
+++ b/librashader-reflect/src/lib.rs
@@ -43,7 +43,7 @@
 //! librashader-reflect is designed to be compiler-agnostic. [naga](https://docs.rs/naga/latest/naga/index.html),
 //! a pure-Rust shader compiler, as well as SPIRV-Cross via [SpirvCompilation](crate::front::SpirvCompilation)
 //! is supported.
-#![cfg_attr(not(feature = "stable"), feature(impl_trait_in_assoc_type))]
+#![cfg_attr(feature = "nightly", feature(impl_trait_in_assoc_type))]
 /// Shader codegen backends.
 pub mod back;
 /// Error types.

--- a/librashader-runtime-d3d11/Cargo.toml
+++ b/librashader-runtime-d3d11/Cargo.toml
@@ -28,7 +28,9 @@ rayon = { workspace = true }
 
 [features]
 debug-shader = []
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/librashader-runtime-d3d11/src/filter_chain.rs
+++ b/librashader-runtime-d3d11/src/filter_chain.rs
@@ -77,16 +77,16 @@ mod compile {
     use super::*;
     use librashader_pack::{PassResource, TextureResource};
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-d3d11/src/lib.rs
+++ b/librashader-runtime-d3d11/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::d3d11`](https://docs.rs/librashader/latest/librashader/runtime/d3d11/index.html) instead.
 
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod draw_quad;
 mod filter_chain;

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -35,7 +35,9 @@ d3d12-descriptor-heap = "0.2"
 rayon = { workspace = true }
 
 [features]
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/librashader-runtime-d3d12/src/filter_chain.rs
+++ b/librashader-runtime-d3d12/src/filter_chain.rs
@@ -178,16 +178,16 @@ mod compile {
     use super::*;
     use librashader_pack::PassResource;
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type DxilShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<DXIL, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type DxilShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<DXIL, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(DxilShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(DxilShaderPassMeta))]
     pub fn compile_passes_dxil(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],
@@ -209,16 +209,16 @@ mod compile {
         Ok((passes, semantics))
     }
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type HlslShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type HlslShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(HlslShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(HlslShaderPassMeta))]
     pub fn compile_passes_hlsl(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-d3d12/src/lib.rs
+++ b/librashader-runtime-d3d12/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod buffer;
 mod descriptor_heap;

--- a/librashader-runtime-d3d9/Cargo.toml
+++ b/librashader-runtime-d3d9/Cargo.toml
@@ -29,7 +29,9 @@ windows-numerics = "0.3.0"
 windows-core = { workspace = true }
 
 [features]
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true

--- a/librashader-runtime-d3d9/src/filter_chain.rs
+++ b/librashader-runtime-d3d9/src/filter_chain.rs
@@ -65,16 +65,16 @@ mod compile {
     use super::*;
     use librashader_pack::{PassResource, TextureResource};
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<HLSL, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-d3d9/src/lib.rs
+++ b/librashader-runtime-d3d9/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(target_os = "windows")]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod binding;
 mod d3dx;

--- a/librashader-runtime-gl/Cargo.toml
+++ b/librashader-runtime-gl/Cargo.toml
@@ -28,7 +28,9 @@ rayon = { workspace = true }
 array-init = "2.1.0"
 
 [features]
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [dev-dependencies]
 glfw = { workspace = true }

--- a/librashader-runtime-gl/src/filter_chain/chain.rs
+++ b/librashader-runtime-gl/src/filter_chain/chain.rs
@@ -103,16 +103,16 @@ impl<T: GLInterface> FilterChainImpl<T> {
 mod compile {
     use super::*;
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<GLSL, SpirvCompilation, SpirvCross>>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<GLSL, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-gl/src/lib.rs
+++ b/librashader-runtime-gl/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::gl`](https://docs.rs/librashader/latest/librashader/runtime/gl/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod binding;
 mod filter_chain;

--- a/librashader-runtime-mtl/Cargo.toml
+++ b/librashader-runtime-mtl/Cargo.toml
@@ -40,7 +40,9 @@ objc2-metal = { workspace = true }
 objc2 = { workspace = true }
 
 [features]
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [target.'cfg(target_vendor="apple")'.dev-dependencies]
 objc2-metal-kit = { version = "0.3" }

--- a/librashader-runtime-mtl/src/filter_chain.rs
+++ b/librashader-runtime-mtl/src/filter_chain.rs
@@ -43,15 +43,15 @@ mod compile {
     use super::*;
     use librashader_pack::{PassResource, TextureResource};
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<MSL, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<Box<dyn CompileReflectShader<MSL, SpirvCompilation, SpirvCross> + Send>>;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-mtl/src/lib.rs
+++ b/librashader-runtime-mtl/src/lib.rs
@@ -4,7 +4,7 @@
 //! See [`librashader::runtime::mtl`](https://docs.rs/librashader/latest/aarch64-apple-darwin/librashader/runtime/mtl/index.html) instead.
 
 #![cfg(target_vendor = "apple")]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod buffer;
 mod draw_quad;

--- a/librashader-runtime-vk/Cargo.toml
+++ b/librashader-runtime-vk/Cargo.toml
@@ -32,7 +32,9 @@ array-concat = "0.5.2"
 ash = { workspace = true, features = ["debug"] }
 
 [features]
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [dev-dependencies]
 num = "0.4.0"

--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -252,16 +252,16 @@ mod compile {
     use super::*;
     use librashader_pack::PassResource;
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<SPIRV, SpirvCompilation, SpirvCross> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta = ShaderPassArtifact<
         Box<dyn CompileReflectShader<SPIRV, SpirvCompilation, SpirvCross> + Send>,
     >;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-vk/src/lib.rs
+++ b/librashader-runtime-vk/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::vk`](https://docs.rs/librashader/latest/librashader/runtime/vk/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod draw_quad;
 mod filter_chain;

--- a/librashader-runtime-wgpu/Cargo.toml
+++ b/librashader-runtime-wgpu/Cargo.toml
@@ -33,7 +33,9 @@ wgpu_dx12 = ["wgpu/dx12"]
 wgpu_metal = ["wgpu/metal"]
 wgpu_webgpu = ["wgpu/webgpu"]
 
-stable = ["librashader-reflect/stable"]
+nightly = ["librashader-reflect/nightly"]
+# Backwards-compatible no-op; stable is the default code path.
+stable = []
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 rayon = { workspace = true }

--- a/librashader-runtime-wgpu/src/filter_chain.rs
+++ b/librashader-runtime-wgpu/src/filter_chain.rs
@@ -40,15 +40,15 @@ mod compile {
     use super::*;
     use librashader_pack::{PassResource, TextureResource};
 
-    #[cfg(not(feature = "stable"))]
+    #[cfg(feature = "nightly")]
     pub type ShaderPassMeta =
         ShaderPassArtifact<impl CompileReflectShader<WGSL, SpirvCompilation, Naga> + Send>;
 
-    #[cfg(feature = "stable")]
+    #[cfg(not(feature = "nightly"))]
     pub type ShaderPassMeta =
         ShaderPassArtifact<Box<dyn CompileReflectShader<WGSL, SpirvCompilation, Naga> + Send>>;
 
-    #[cfg_attr(not(feature = "stable"), define_opaque(ShaderPassMeta))]
+    #[cfg_attr(feature = "nightly", define_opaque(ShaderPassMeta))]
     pub fn compile_passes(
         shaders: Vec<PassResource>,
         textures: &[TextureResource],

--- a/librashader-runtime-wgpu/src/lib.rs
+++ b/librashader-runtime-wgpu/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate should not be used directly.
 //! See [`librashader::runtime::wgpu`](https://docs.rs/librashader/latest/librashader/runtime/wgpu/index.html) instead.
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(not(feature = "stable"), feature(type_alias_impl_trait))]
+#![cfg_attr(feature = "nightly", feature(type_alias_impl_trait))]
 
 mod buffer;
 mod draw_quad;

--- a/librashader.copr.spec
+++ b/librashader.copr.spec
@@ -29,8 +29,7 @@ Provides:       librashader
 {{{ git_dir_setup_macro }}}
 
 %build
-# need to use stable compiler, but enable nightly features
-RUSTC_BOOTSTRAP=1 cargo run -p librashader-build-script -- --profile %{profile}
+cargo run -p librashader-build-script -- --profile %{profile}
 
 %install
 mkdir -p %{buildroot}/%{_libdir}
@@ -38,7 +37,7 @@ mkdir -p %{buildroot}/%{_includedir}/librashader
 patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
 install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
 ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
 cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 

--- a/librashader/Cargo.toml
+++ b/librashader/Cargo.toml
@@ -48,15 +48,18 @@ runtime = []
 reflect = []
 preprocess = []
 presets = []
-stable = [ "librashader-reflect/stable",
-           "librashader-runtime-d3d9?/stable",
-           "librashader-runtime-d3d11?/stable",
-           "librashader-runtime-d3d12?/stable",
-           "librashader-runtime-gl?/stable",
-           "librashader-runtime-vk?/stable",
-           "librashader-runtime-mtl?/stable",
-           "librashader-runtime-wgpu?/stable"
+nightly = [ "librashader-reflect/nightly",
+            "librashader-runtime-d3d9?/nightly",
+            "librashader-runtime-d3d11?/nightly",
+            "librashader-runtime-d3d12?/nightly",
+            "librashader-runtime-gl?/nightly",
+            "librashader-runtime-vk?/nightly",
+            "librashader-runtime-mtl?/nightly",
+            "librashader-runtime-wgpu?/nightly"
 ]
+# Backwards-compatible no-op; stable is the default code path. Kept so older
+# consumers that pass `features = ["stable"]` continue to build.
+stable = []
 # runtimes
 
 runtime-gl = [ "runtime", "reflect-cross", "librashader-common/opengl", "librashader-runtime-gl" ]

--- a/pkg/librashader.spec
+++ b/pkg/librashader.spec
@@ -28,8 +28,7 @@ Provides:       librashader
 %autosetup -n %{name}-%{commit}
 
 %build
-# need to use stable compiler, but enable nightly features
-RUSTC_BOOTSTRAP=1 cargo run -p librashader-build-script -- --profile %{profile}
+cargo run -p librashader-build-script -- --profile %{profile}
 
 %install
 mkdir -p %{buildroot}/%{_libdir}
@@ -37,7 +36,7 @@ mkdir -p %{buildroot}/%{_includedir}/librashader
 patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
 install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
 ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
 cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 

--- a/pkg/obs/PKGBUILD
+++ b/pkg/obs/PKGBUILD
@@ -15,11 +15,11 @@ profile="optimized"
 
 build() {
   cd $pkgname-$pkgver
-  mkdir .cargo               
+  mkdir .cargo
   cp "$srcdir/cargo_config" .cargo/config
   cp -r "$srcdir/vendor" "vendor"
   cp "$srcdir/Cargo.lock" "Cargo.lock"
-  RUSTC_BOOTSTRAP=1 cargo run -p librashader-build-script -- --profile ${profile}
+  cargo run -p librashader-build-script -- --profile ${profile}
 
 }
 
@@ -29,6 +29,6 @@ package() {
   patchelf --set-soname librashader.so.2 $srcdir/$pkgname-$pkgver/target/$profile/librashader.so
   install -m 0755 $srcdir/$pkgname-$pkgver/target/${profile}/librashader.so $pkgdir/usr/lib/librashader.so.2
   ln -s librashader.so.2 $pkgdir/usr/lib/librashader.so
-  cp $srcdir/$pkgname-$pkgver/target/${profile}/librashader.h $pkgdir/usr/include/librashader/librashader.h
+  cp $srcdir/$pkgname-$pkgver/include/librashader.h $pkgdir/usr/include/librashader/librashader.h
   cp $srcdir/$pkgname-$pkgver/include/librashader_ld.h $pkgdir/usr/include/librashader/librashader_ld.h
 }

--- a/pkg/obs/librashader.spec
+++ b/pkg/obs/librashader.spec
@@ -27,7 +27,7 @@ mkdir .cargo                # cargo automatically uses this dir
 cp %{SOURCE2} .cargo/config # and automatically uses this config
 
 %build
-RUSTC_BOOTSTRAP=1 cargo run --ignore-rust-version -p librashader-build-script -- --profile %{profile}
+cargo run -p librashader-build-script -- --profile %{profile}
 
 %install
 mkdir -p %{buildroot}/%{_libdir}
@@ -35,7 +35,7 @@ mkdir -p %{buildroot}/%{_includedir}/librashader
 patchelf --set-soname librashader.so.2 target/%{profile}/librashader.so
 install -m 0755 target/%{profile}/librashader.so %{buildroot}%{_libdir}/librashader.so.2
 ln -s librashader.so.2 %{buildroot}%{_libdir}/librashader.so
-cp target/%{profile}/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
+cp include/librashader.h %{buildroot}%{_includedir}/librashader/librashader.h
 cp include/librashader_ld.h %{buildroot}%{_includedir}/librashader/librashader_ld.h
 
 


### PR DESCRIPTION
Since C API generation is broken and `impl Trait` buys us exactly one allocation, it's not worth the distribution headache of relying on RUST_BOOTSTRAP or nightly Rust. Just default to the `stable` feature from now on.

Fixes #55 