### PR TITLE
rt(d3d12): optionally allow statically built dxc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "bytemuck",
  "librashader-preprocess",
  "librashader-reflect",
+ "mach-dxcompiler-rs",
  "parking_lot",
  "persy",
  "platform-dirs",
@@ -1728,6 +1729,7 @@ dependencies = [
  "librashader-presets",
  "librashader-reflect",
  "librashader-runtime",
+ "mach-dxcompiler-rs",
  "mach-siegbert-vogt-dxcsa",
  "parking_lot",
  "rayon",
@@ -1897,6 +1899,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach-dxcompiler-rs"
+version = "0.1.4+2024.11.22-df583a3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3cd67e8ea2ba061339150970542cf1c60ba44c6d17e31279cbc133a4b018f8"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "mach-siegbert-vogt-dxcsa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ wgpu-types = { version = "29.0.3" }
 clap = { version = "=4.3.0", features = ["derive"] }
 rayon = { version = "1.10.0"}
 gpu-allocator = { version = "0.28.0", default-features = false, features = ["hashbrown"] }
+mach-dxcompiler-rs = { version = "0.1.4+2024.11.22-df583a3.1" }
 
 [workspace.dependencies.image]
 version = "0.25.8"

--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Please report an issue if you run into a shader that works in RetroArch, but not
     which was released in late 2018.
   * For maximum compatibility with shaders, a shader compile pipeline based on [`spirv-to-dxil`](https://github.com/SnowflakePowered/spirv-to-dxil-rs) is used, with the SPIRV-Cross HLSL pipeline used as a fallback. 
     This brings shader compatibility beyond what the RetroArch Direct3D 12 driver provides. The HLSL pipeline fallback may be removed in the future as `spirv-to-dxil` improves.
-  * The Direct3D 12 runtime requires `dxcompiler.dll` from the [DirectX Shader Compiler](https://github.com/microsoft/DirectXShaderCompiler), which may already be installed as part of Direct3D12. `dxil.dll` is not required.
+  * By default, the Direct3D 12 runtime requires `dxcompiler.dll` from the [DirectX Shader Compiler](https://github.com/microsoft/DirectXShaderCompiler), which may already be installed as part of Direct3D12. `dxil.dll` is not required.
+    Building with the `runtime-d3d12-static` feature will include a static (albeit outdated) copy of Dxc, removing the requirement. This feature is only supported on `x86_64`; ARM64 builds will fallback to requiring `dxcompiler.dll`.
 * Metal
   * The Metal runtime uses the same VBOs as the other runtimes as well as the identity matrix MVP for intermediate passes. RetroArch's Metal driver uses only the final VBO.
 

--- a/librashader-cache/Cargo.toml
+++ b/librashader-cache/Cargo.toml
@@ -17,7 +17,7 @@ librashader-preprocess = { path = "../librashader-preprocess", version = "0.10.1
 platform-dirs = "0.3.0"
 blake3 = { version = "1.5.4" }
 thiserror = "2"
-bincode = { version = "2.0.0-rc.2", features = ["serde"] }
+bincode = { version = "2.0.0", features = ["serde"] }
 persy = "1.6.0"
 
 parking_lot = "0.12.5"
@@ -36,8 +36,13 @@ features = [
 ]
 optional = true
 
+[target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies.mach-dxcompiler-rs]
+workspace = true
+optional = true
+
 [features]
 d3d = ["windows", "librashader-reflect/dxil"]
+dxcompiler-static = ["mach-dxcompiler-rs"]
 
 # hack to get building on docsrs
 docsrs = ["blake3/pure"]

--- a/librashader-cache/src/d3d.rs
+++ b/librashader-cache/src/d3d.rs
@@ -4,6 +4,28 @@
 use crate::{CacheKey, Cacheable};
 use windows::core::Interface;
 
+#[cfg(not(all(feature = "dxcompiler-static", target_arch = "x86_64")))]
+use windows::Win32::Graphics::Direct3D::Dxc::DxcCreateInstance;
+
+#[cfg(all(feature = "dxcompiler-static", target_arch = "x86_64"))]
+#[inline]
+#[allow(non_snake_case)]
+unsafe fn DxcCreateInstance<T>(rclsid: *const windows::core::GUID) -> windows::core::Result<T>
+where
+    T: windows::core::Interface,
+{
+    let mut result__ = core::ptr::null_mut();
+    unsafe {
+        let hresult = mach_dxcompiler_rs::DxcCreateInstance(
+            rclsid as *const core::ffi::c_void,
+            &T::IID as *const _ as *const core::ffi::c_void,
+            &mut result__,
+        );
+        let hresult = windows::core::HRESULT(hresult);
+        hresult.and_then(|| windows::core::Type::from_abi(result__))
+    }
+}
+
 impl CacheKey for windows::Win32::Graphics::Direct3D::ID3DBlob {
     fn hash_bytes(&self) -> &[u8] {
         unsafe { std::slice::from_raw_parts(self.GetBufferPointer().cast(), self.GetBufferSize()) }
@@ -45,19 +67,17 @@ impl Cacheable for windows::Win32::Graphics::Direct3D::ID3DBlob {
 impl Cacheable for windows::Win32::Graphics::Direct3D::Dxc::IDxcBlob {
     fn from_bytes(bytes: &[u8]) -> Option<Self> {
         let Some(blob) = (unsafe {
-            windows::Win32::Graphics::Direct3D::Dxc::DxcCreateInstance(
-                &windows::Win32::Graphics::Direct3D::Dxc::CLSID_DxcLibrary,
-            )
-            .and_then(
-                |library: windows::Win32::Graphics::Direct3D::Dxc::IDxcUtils| {
-                    library.CreateBlob(
-                        bytes.as_ptr().cast(),
-                        bytes.len() as u32,
-                        windows::Win32::Graphics::Direct3D::Dxc::DXC_CP(0),
-                    )
-                },
-            )
-            .ok()
+            DxcCreateInstance(&windows::Win32::Graphics::Direct3D::Dxc::CLSID_DxcLibrary)
+                .and_then(
+                    |library: windows::Win32::Graphics::Direct3D::Dxc::IDxcUtils| {
+                        library.CreateBlob(
+                            bytes.as_ptr().cast(),
+                            bytes.len() as u32,
+                            windows::Win32::Graphics::Direct3D::Dxc::DXC_CP(0),
+                        )
+                    },
+                )
+                .ok()
         }) else {
             return None;
         };

--- a/librashader-capi/Cargo.toml
+++ b/librashader-capi/Cargo.toml
@@ -25,6 +25,8 @@ runtime-d3d9 = ["windows", "librashader/runtime-d3d9", "windows/Win32_Graphics_D
 runtime-vulkan = ["ash", "librashader/runtime-vk"]
 runtime-metal = ["__cbindgen_internal_objc", "librashader/runtime-metal"]
 
+runtime-d3d12-static = [ "runtime-d3d12", "librashader/runtime-d3d12-static"]
+
 reflect-unstable = []
 nightly = ["librashader/nightly"]
 # Backwards-compatible no-op; stable is the default code path.

--- a/librashader-capi/build.rs
+++ b/librashader-capi/build.rs
@@ -2,7 +2,14 @@ pub fn main() {
     #[cfg(all(target_os = "windows", feature = "runtime-d3d12"))]
     {
         println!("cargo:rustc-link-lib=dylib=delayimp");
-        println!("cargo:rustc-link-arg=/DELAYLOAD:dxcompiler.dll");
         println!("cargo:rustc-link-arg=/DELAYLOAD:d3d12.dll");
+    }
+    #[cfg(all(
+        target_os = "windows",
+        feature = "runtime-d3d12",
+        not(all(feature = "runtime-d3d12-static", target_arch = "x86_64"))
+    ))]
+    {
+        println!("cargo:rustc-link-arg=/DELAYLOAD:dxcompiler.dll");
     }
 }

--- a/librashader-cli/Cargo.toml
+++ b/librashader-cli/Cargo.toml
@@ -53,7 +53,7 @@ opengl = ["librashader/runtime-gl", "dep:glow", "dep:glfw"]
 wgpu = ["librashader/runtime-wgpu", "dep:wgpu", "dep:wgpu-types"]
 
 d3d11 = ["librashader/runtime-d3d11", "dep:windows"]
-d3d12 = ["librashader/runtime-d3d12", "dep:windows", "dep:d3d12-descriptor-heap"]
+d3d12 = ["librashader/runtime-d3d12", "librashader/runtime-d3d12-static", "dep:windows", "dep:d3d12-descriptor-heap"]
 d3d9 = ["librashader/runtime-d3d9", "dep:windows"]
 
 metal = ["librashader/runtime-metal", "dep:objc2", "dep:objc2-metal"]

--- a/librashader-cli/src/render/vk/base.rs
+++ b/librashader-cli/src/render/vk/base.rs
@@ -38,8 +38,7 @@ impl VulkanBase {
             .application_version(0)
             .api_version(vk::make_api_version(0, 1, 0, 0));
 
-        let create_info = vk::InstanceCreateInfo::default()
-            .application_info(&app_info);
+        let create_info = vk::InstanceCreateInfo::default().application_info(&app_info);
 
         let instance = unsafe { entry.create_instance(&create_info, None) }?;
 
@@ -92,8 +91,7 @@ impl VulkanBase {
             .queue_family_index(indices.graphics_family()?)
             .queue_priorities(&[1.0f32])];
 
-        let device_create_info = vk::DeviceCreateInfo::default()
-            .queue_create_infos(&queue_info);
+        let device_create_info = vk::DeviceCreateInfo::default().queue_create_infos(&queue_info);
 
         let device =
             unsafe { instance.create_device(*physical_device, &device_create_info, None)? };

--- a/librashader-runtime-d3d12/Cargo.toml
+++ b/librashader-runtime-d3d12/Cargo.toml
@@ -39,6 +39,12 @@ nightly = ["librashader-reflect/nightly"]
 # Backwards-compatible no-op; stable is the default code path.
 stable = []
 
+static = ["mach-dxcompiler-rs", "librashader-cache/dxcompiler-static"]
+
+[target.'cfg(all(windows, target_arch = "x86_64"))'.dependencies.mach-dxcompiler-rs]
+workspace = true
+optional = true
+
 [target.'cfg(windows)'.dependencies.windows]
 workspace = true
 features = [

--- a/librashader-runtime-d3d12/src/filter_chain.rs
+++ b/librashader-runtime-d3d12/src/filter_chain.rs
@@ -10,6 +10,7 @@ use crate::mipmap::D3D12MipmapGen;
 use crate::options::{FilterChainOptionsD3D12, FrameOptionsD3D12};
 use crate::samplers::SamplerSet;
 use crate::texture::{D3D12InputImage, D3D12OutputView, InputTexture, OutputDescriptor};
+use crate::util::DxcCreateInstance;
 use crate::{error, util};
 use d3d12_descriptor_heap::{
     D3D12DescriptorHeap, D3D12DescriptorHeapSlot, D3D12PartitionableHeap, D3D12PartitionedHeap,
@@ -36,8 +37,7 @@ use std::sync::Arc;
 use windows::core::Interface;
 use windows::Win32::Foundation::CloseHandle;
 use windows::Win32::Graphics::Direct3D::Dxc::{
-    CLSID_DxcCompiler, CLSID_DxcLibrary, CLSID_DxcValidator, DxcCreateInstance, IDxcCompiler,
-    IDxcUtils, IDxcValidator,
+    CLSID_DxcCompiler, CLSID_DxcLibrary, CLSID_DxcValidator, IDxcCompiler, IDxcUtils, IDxcValidator,
 };
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12CommandAllocator, ID3D12CommandQueue, ID3D12DescriptorHeap, ID3D12Device, ID3D12Fence,

--- a/librashader-runtime-d3d12/src/graphics_pipeline.rs
+++ b/librashader-runtime-d3d12/src/graphics_pipeline.rs
@@ -1,6 +1,7 @@
 use crate::draw_quad::DrawQuad;
 use crate::error::assume_d3d12_init;
 use crate::error::FilterChainError::Direct3DOperationError;
+use crate::util::DxcCreateInstance;
 use crate::{error, util};
 use librashader_cache::{cache_pipeline, cache_shader_object};
 use librashader_common::map::FastHashMap;
@@ -13,7 +14,7 @@ use std::ops::Deref;
 use widestring::u16cstr;
 use windows::core::Interface;
 use windows::Win32::Graphics::Direct3D::Dxc::{
-    CLSID_DxcLibrary, DxcCreateInstance, IDxcBlob, IDxcCompiler, IDxcUtils, IDxcValidator, DXC_CP,
+    CLSID_DxcLibrary, IDxcBlob, IDxcCompiler, IDxcUtils, IDxcValidator, DXC_CP,
 };
 use windows::Win32::Graphics::Direct3D12::{
     D3D12SerializeVersionedRootSignature, ID3D12Device, ID3D12PipelineState, ID3D12RootSignature,

--- a/librashader-runtime-d3d12/src/mipmap.rs
+++ b/librashader-runtime-d3d12/src/mipmap.rs
@@ -1,22 +1,22 @@
 use crate::descriptor_heap::ResourceWorkHeap;
 use crate::resource::{ObtainResourceHandle, ResourceHandleStrategy};
 use crate::util::dxc_validate_shader;
+use crate::util::DxcCreateInstance;
 use crate::{error, util};
+
 use bytemuck::{Pod, Zeroable};
 use d3d12_descriptor_heap::{D3D12DescriptorHeap, D3D12DescriptorHeapSlot};
 use librashader_common::Size;
 use librashader_runtime::scaling::MipmapSize;
 use std::mem::ManuallyDrop;
 
-use windows::Win32::Graphics::Direct3D::Dxc::{
-    CLSID_DxcLibrary, CLSID_DxcValidator, DxcCreateInstance,
-};
+use windows::Win32::Graphics::Direct3D::Dxc::{CLSID_DxcLibrary, CLSID_DxcValidator};
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12DescriptorHeap, ID3D12Device, ID3D12GraphicsCommandList, ID3D12PipelineState,
     ID3D12RootSignature, D3D12_COMPUTE_PIPELINE_STATE_DESC,
     D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING, D3D12_RESOURCE_BARRIER, D3D12_RESOURCE_BARRIER_0,
-    D3D12_RESOURCE_BARRIER_TYPE_UAV, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE,
-    D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+    D3D12_RESOURCE_BARRIER_TYPE_UAV, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+    D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
     D3D12_RESOURCE_UAV_BARRIER, D3D12_SHADER_BYTECODE, D3D12_SHADER_RESOURCE_VIEW_DESC,
     D3D12_SHADER_RESOURCE_VIEW_DESC_0, D3D12_SRV_DIMENSION_TEXTURE2D, D3D12_TEX2D_SRV,
     D3D12_TEX2D_UAV, D3D12_UAV_DIMENSION_TEXTURE2D, D3D12_UNORDERED_ACCESS_VIEW_DESC,

--- a/librashader-runtime-d3d12/src/util.rs
+++ b/librashader-runtime-d3d12/src/util.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use std::mem::ManuallyDrop;
 use widestring::{u16cstr, U16CStr};
-use windows::core::{Interface, PCWSTR};
+use windows::core::{Interface, HRESULT, PCWSTR};
 use windows::Win32::Graphics::Direct3D::Dxc::{
     DxcValidatorFlags_InPlaceEdit, IDxcBlob, IDxcCompiler, IDxcUtils, IDxcValidator, DXC_CP,
     DXC_CP_UTF8,
@@ -229,3 +229,25 @@ fn d3d12_resource_transition_subresource<S: ResourceHandleStrategy<T>, T>(
     unsafe { cmd.ResourceBarrier(&barrier) }
     barrier
 }
+
+#[cfg(all(feature = "static", target_arch = "x86_64"))]
+#[inline]
+#[allow(non_snake_case)]
+pub unsafe fn DxcCreateInstance<T>(rclsid: *const windows::core::GUID) -> windows::core::Result<T>
+where
+    T: windows::core::Interface,
+{
+    let mut result__ = core::ptr::null_mut();
+    unsafe {
+        let hresult = mach_dxcompiler_rs::DxcCreateInstance(
+            rclsid as *const core::ffi::c_void,
+            &T::IID as *const _ as *const core::ffi::c_void,
+            &mut result__,
+        );
+        let hresult = HRESULT(hresult);
+        hresult.and_then(|| windows::core::Type::from_abi(result__))
+    }
+}
+
+#[cfg(not(all(feature = "static", target_arch = "x86_64")))]
+pub use windows::Win32::Graphics::Direct3D::Dxc::DxcCreateInstance;

--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -819,8 +819,7 @@ impl FilterChainVulkan {
             let output_size_override = if self.draw_last_pass_feedback {
                 let target = &self.output_framebuffers[index];
 
-                let output_image =
-                    OutputImage::new(&self.vulkan.device, target.image.clone())?;
+                let output_image = OutputImage::new(&self.vulkan.device, target.image.clone())?;
                 let out = RenderTarget::viewport_with_output(&output_image, viewport);
 
                 let residual_fb = pass.draw(

--- a/librashader/Cargo.toml
+++ b/librashader/Cargo.toml
@@ -48,6 +48,7 @@ runtime = []
 reflect = []
 preprocess = []
 presets = []
+
 nightly = [ "librashader-reflect/nightly",
             "librashader-runtime-d3d9?/nightly",
             "librashader-runtime-d3d11?/nightly",
@@ -65,6 +66,8 @@ stable = []
 runtime-gl = [ "runtime", "reflect-cross", "librashader-common/opengl", "librashader-runtime-gl" ]
 runtime-d3d11 = [ "runtime", "reflect-cross","librashader-common/d3d11", "librashader-runtime-d3d11", "windows/Win32_Graphics_Direct3D11" ]
 runtime-d3d12 = [ "runtime", "reflect-cross", "reflect-dxil", "librashader-common/d3d12", "librashader-runtime-d3d12", "windows/Win32_Graphics_Direct3D12" ]
+runtime-d3d12-static = [ "librashader-runtime-d3d12?/static"]
+
 runtime-d3d9 = [ "runtime", "reflect-cross", "librashader-common/d3d9", "librashader-runtime-d3d9", "windows/Win32_Graphics_Direct3D9" ]
 
 runtime-vk = ["runtime", "reflect-cross", "librashader-common/vulkan", "librashader-runtime-vk", "ash" ]


### PR DESCRIPTION
Use `mach-dxcompiler-d3d12` for optional statically build DXC.

The default path is still the alongside dxcompiler.dll though (or Agility SDK if installed).