### PR TITLE
fix(d3d11): do resource creation on main thread

### DIFF
--- a/librashader-cache/src/cache.rs
+++ b/librashader-cache/src/cache.rs
@@ -190,6 +190,66 @@ where
     })
 }
 
+/// Cache a shader object (usually bytecode) created by the keyed objects, deferring the load step.
+///
+/// This behaves like [`cache_shader_object`], except that `load` is not executed immediately.
+/// Instead, the compiled (or cached) shader object is curried into the returned closure, which can
+/// be invoked later to produce the driver-specialized result. This allows shader objects to be
+/// compiled in parallel via `factory`, then have their driver resources created sequentially by the
+/// returned closures, for drivers whose object creation is not safe to call concurrently.
+///
+/// Because `load` is deferred, a cached shader object can not be validated by `load` at fetch time:
+/// unlike [`cache_shader_object`], a cached object that fails to load will not be transparently
+/// recompiled.
+pub fn cache_shader_object_deferred<'a, E, T, R, H, const KEY_SIZE: usize>(
+    index: &str,
+    keys: &[H; KEY_SIZE],
+    factory: impl Fn(&[H; KEY_SIZE]) -> Result<T, E> + std::panic::RefUnwindSafe,
+    load: impl FnOnce(T) -> Result<R, E> + Send + 'a,
+    bypass_cache: bool,
+) -> Result<Box<dyn FnOnce() -> Result<R, E> + Send + 'a>, E>
+where
+    H: CacheKey + std::panic::RefUnwindSafe,
+    T: Cacheable + Send + 'a,
+{
+    let object = if bypass_cache {
+        factory(keys)
+    } else {
+        catch_unwind(|| {
+            let Ok(cache) = internal::get_cache() else {
+                return factory(keys);
+            };
+
+            let hashkey = {
+                let mut hasher = blake3::Hasher::new();
+                for subkeys in keys {
+                    hasher.update(subkeys.hash_bytes());
+                }
+                hasher.finalize()
+            };
+
+            if let Ok(Some(blob)) = internal::get_blob(&cache, index, hashkey.as_bytes()) {
+                if let Some(cached) = T::from_bytes(&blob) {
+                    return Ok(cached);
+                }
+            }
+
+            let blob = factory(keys)?;
+
+            if let Some(slice) = T::to_bytes(&blob) {
+                let _ = internal::set_blob(&cache, index, hashkey.as_bytes(), &slice);
+            }
+            Ok(blob)
+        })
+        .unwrap_or_else(|_| {
+            internal::remove_cache();
+            factory(keys)
+        })
+    }?;
+
+    Ok(Box::new(move || load(object)))
+}
+
 /// Cache a pipeline state object.
 ///
 /// Keys are not used to create the object and are only used to uniquely identify the pipeline state.

--- a/librashader-cache/src/lib.rs
+++ b/librashader-cache/src/lib.rs
@@ -17,6 +17,7 @@ pub use compilation::CachedCompilation;
 
 pub use cache::cache_pipeline;
 pub use cache::cache_shader_object;
+pub use cache::cache_shader_object_deferred;
 
 #[cfg(all(target_os = "windows", feature = "d3d"))]
 mod d3d;

--- a/librashader-reflect/src/back/spirv.rs
+++ b/librashader-reflect/src/back/spirv.rs
@@ -49,7 +49,8 @@ mod cross {
         type Target = SPIRV;
         type Options = Option<()>;
         type Context = ();
-        type Output = Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross> + Send>;
+        type Output =
+            Box<dyn CompileReflectShader<Self::Target, SpirvCompilation, SpirvCross> + Send>;
 
         fn from_compilation(
             compile: SpirvCompilation,
@@ -115,8 +116,8 @@ pub(crate) use cross::*;
 #[cfg(feature = "naga")]
 mod naga {
     use super::*;
-    use ::naga::Module;
     use crate::reflect::naga::{Naga, NagaLoweringOptions, NagaReflect};
+    use ::naga::Module;
 
     /// The context for a SPIRV compilation via Naga
     pub struct NagaSpirvContext {

--- a/librashader-runtime-d3d11/src/filter_chain.rs
+++ b/librashader-runtime-d3d11/src/filter_chain.rs
@@ -23,7 +23,7 @@ use crate::options::{FilterChainOptionsD3D11, FrameOptionsD3D11};
 use crate::samplers::SamplerSet;
 use crate::util::d3d11_compile_bound_shader;
 use crate::{error, util};
-use librashader_cache::cache_shader_object;
+use librashader_cache::cache_shader_object_deferred;
 use librashader_cache::CachedCompilation;
 use librashader_common::GetSize;
 use librashader_presets::context::VideoDriver;
@@ -284,14 +284,11 @@ impl FilterChainD3D11 {
         semantics: &ShaderSemantics,
         disable_cache: bool,
     ) -> error::Result<Vec<FilterPass>> {
-        let device_is_singlethreaded =
-            unsafe { (device.GetCreationFlags() & D3D11_CREATE_DEVICE_SINGLETHREADED.0) == 1 };
-
-        let builder_fn = |(index, (config, mut reflect)): (usize, ShaderPassMeta)| {
+        let compile_fn = |(index, (config, mut reflect)): (usize, ShaderPassMeta)| {
             let reflection = reflect.reflect(index, semantics)?;
             let hlsl = reflect.compile(None)?;
 
-            let (vs, vertex_dxbc) = cache_shader_object(
+            let vs = cache_shader_object_deferred(
                 "dxbc",
                 &[hlsl.vertex.as_bytes()],
                 |&[bytes]| util::d3d_compile_shader(bytes, b"main\0", b"vs_5_0\0"),
@@ -309,10 +306,7 @@ impl FilterChainD3D11 {
                 disable_cache,
             )?;
 
-            let ia_desc = DrawQuad::get_spirv_cross_vbo_desc();
-            let vao = util::d3d11_create_input_layout(device, &ia_desc, &vertex_dxbc)?;
-
-            let ps = cache_shader_object(
+            let ps = cache_shader_object_deferred(
                 "dxbc",
                 &[hlsl.fragment.as_bytes()],
                 |&[bytes]| util::d3d_compile_shader(bytes, b"main\0", b"ps_5_0\0"),
@@ -322,70 +316,81 @@ impl FilterChainD3D11 {
                 disable_cache,
             )?;
 
-            let ubo_cbuffer =
-                if let Some(ubo) = &reflection.ubo.as_ref().filter(|ubo| ubo.size != 0) {
-                    let buffer = FilterChainD3D11::create_constant_buffer(device, ubo.size)?;
+            Ok::<_, FilterChainError>((reflection, config, vs, ps))
+        };
+
+        // D3DCompiler is always thread safe, and even if Direct3D11Device is "thread safe",
+        // reshade is not, so we always need to do the DXBC -> Driver bytecode conversion in
+        // serial
+        let compiled: Vec<_> = passes
+            .into_par_iter()
+            .enumerate()
+            .map(compile_fn)
+            .collect::<error::Result<_>>()?;
+
+        compiled
+            .into_iter()
+            .map(|(reflection, config, vs, ps)| {
+                let (vs, vertex_dxbc) = vs()?;
+
+                let ia_desc = DrawQuad::get_spirv_cross_vbo_desc();
+                let vao = util::d3d11_create_input_layout(device, &ia_desc, &vertex_dxbc)?;
+
+                let ps = ps()?;
+
+                let ubo_cbuffer =
+                    if let Some(ubo) = &reflection.ubo.as_ref().filter(|ubo| ubo.size != 0) {
+                        let buffer = FilterChainD3D11::create_constant_buffer(device, ubo.size)?;
+                        Some(ConstantBufferBinding {
+                            binding: ubo.binding,
+                            size: ubo.size,
+                            stage_mask: ubo.stage_mask,
+                            buffer,
+                        })
+                    } else {
+                        None
+                    };
+
+                let push_cbuffer = if let Some(push) = &reflection
+                    .push_constant
+                    .as_ref()
+                    .filter(|push| push.size != 0)
+                {
+                    let buffer = FilterChainD3D11::create_constant_buffer(device, push.size)?;
                     Some(ConstantBufferBinding {
-                        binding: ubo.binding,
-                        size: ubo.size,
-                        stage_mask: ubo.stage_mask,
+                        binding: if ubo_cbuffer.is_some() { 1 } else { 0 },
+                        size: push.size,
+                        stage_mask: push.stage_mask,
                         buffer,
                     })
                 } else {
                     None
                 };
 
-            let push_cbuffer = if let Some(push) = &reflection
-                .push_constant
-                .as_ref()
-                .filter(|push| push.size != 0)
-            {
-                let buffer = FilterChainD3D11::create_constant_buffer(device, push.size)?;
-                Some(ConstantBufferBinding {
-                    binding: if ubo_cbuffer.is_some() { 1 } else { 0 },
-                    size: push.size,
-                    stage_mask: push.stage_mask,
-                    buffer,
+                let uniform_storage = UniformStorage::new(
+                    reflection.ubo.as_ref().map_or(0, |ubo| ubo.size as usize),
+                    reflection
+                        .push_constant
+                        .as_ref()
+                        .map_or(0, |push| push.size as usize),
+                );
+
+                let uniform_bindings = reflection.meta.create_binding_map(|param| param.offset());
+
+                Ok(FilterPass {
+                    reflection,
+                    vertex_shader: vs,
+                    vertex_layout: vao,
+                    pixel_shader: ps,
+                    uniform_bindings,
+                    uniform_storage,
+                    uniform_buffer: ubo_cbuffer,
+                    push_buffer: push_cbuffer,
+                    source: config.data,
+                    meta: config.meta,
                 })
-            } else {
-                None
-            };
-
-            let uniform_storage = UniformStorage::new(
-                reflection.ubo.as_ref().map_or(0, |ubo| ubo.size as usize),
-                reflection
-                    .push_constant
-                    .as_ref()
-                    .map_or(0, |push| push.size as usize),
-            );
-
-            let uniform_bindings = reflection.meta.create_binding_map(|param| param.offset());
-
-            Ok(FilterPass {
-                reflection,
-                vertex_shader: vs,
-                vertex_layout: vao,
-                pixel_shader: ps,
-                uniform_bindings,
-                uniform_storage,
-                uniform_buffer: ubo_cbuffer,
-                push_buffer: push_cbuffer,
-                source: config.data,
-                meta: config.meta,
             })
-        };
-
-        let filters: Vec<error::Result<FilterPass>> = if device_is_singlethreaded {
-            // D3D11Device is not thread safe
-            passes.into_iter().enumerate().map(builder_fn).collect()
-        } else {
-            // D3D11Device is thread safe
-            passes.into_par_iter().enumerate().map(builder_fn).collect()
-        };
-
-        let filters: error::Result<Vec<FilterPass>> = filters.into_iter().collect();
-        let filters = filters?;
-        Ok(filters)
+            .collect()
     }
 
     fn push_history(

--- a/librashader/src/lib.rs
+++ b/librashader/src/lib.rs
@@ -221,9 +221,9 @@ pub mod reflect {
     #[cfg_attr(feature = "docsrs", doc(cfg(feature = "reflect-naga")))]
     pub mod naga {
         pub use librashader_reflect::back::wgsl::NagaWgslContext;
+        pub use librashader_reflect::front::WgslCompilation;
         pub use librashader_reflect::reflect::naga::Naga;
         pub use librashader_reflect::reflect::naga::NagaLoweringOptions;
-        pub use librashader_reflect::front::WgslCompilation;
     }
 
     pub use librashader_reflect::reflect::semantics::BindingMeta;


### PR DESCRIPTION
Unconditionally thread the FXC compilation but always do resource creation single threadedly to avoid ReShade lockups