### PR TITLE
d3d12: viewport param scissor fix, clear color fix

### DIFF
--- a/librashader-runtime-d3d12/src/filter_pass.rs
+++ b/librashader-runtime-d3d12/src/filter_pass.rs
@@ -24,6 +24,8 @@ use windows::core::Interface;
 use windows::Win32::Foundation::RECT;
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12GraphicsCommandList, ID3D12GraphicsCommandList4, D3D12_RENDER_PASS_BEGINNING_ACCESS,
+    D3D12_RENDER_PASS_BEGINNING_ACCESS_0, D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS,
+    D3D12_CLEAR_VALUE, D3D12_CLEAR_VALUE_0,
     D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS,
     D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, D3D12_RENDER_PASS_FLAG_NONE,
     D3D12_RENDER_PASS_RENDER_TARGET_DESC, D3D12_VIEWPORT,
@@ -206,12 +208,25 @@ impl FilterPass {
         // todo: check for non-renderpass.
 
         let cmd = cmd.cast::<ID3D12GraphicsCommandList4>()?;
+
+        // Define the clear color
+        let clear_value = D3D12_CLEAR_VALUE {
+            Format: output.output.format,
+            Anonymous: D3D12_CLEAR_VALUE_0 {
+                Color: [0.0, 0.0, 0.0, 1.0],
+            },
+        };
+
         unsafe {
             let pass = [D3D12_RENDER_PASS_RENDER_TARGET_DESC {
                 cpuDescriptor: *output.output.descriptor.as_ref(),
                 BeginningAccess: D3D12_RENDER_PASS_BEGINNING_ACCESS {
                     Type: D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR,
-                    ..Default::default()
+                    Anonymous: D3D12_RENDER_PASS_BEGINNING_ACCESS_0 {
+                        Clear: D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETERS {
+                            ClearValue: clear_value,
+                        },
+                    },
                 },
                 EndingAccess: D3D12_RENDER_PASS_ENDING_ACCESS {
                     Type: D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE,
@@ -219,6 +234,8 @@ impl FilterPass {
                 },
             }];
 
+            // This isn't compatible with TYPE_DISCARD and shouldn't be used
+            // May work with PRESERVED, but for optimized clear use param above
             /*
             cmd.ClearRenderTargetView(
                 *output.output.descriptor.as_ref(),

--- a/librashader-runtime-d3d12/src/filter_pass.rs
+++ b/librashader-runtime-d3d12/src/filter_pass.rs
@@ -24,7 +24,7 @@ use windows::core::Interface;
 use windows::Win32::Foundation::RECT;
 use windows::Win32::Graphics::Direct3D12::{
     ID3D12GraphicsCommandList, ID3D12GraphicsCommandList4, D3D12_RENDER_PASS_BEGINNING_ACCESS,
-    D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD, D3D12_RENDER_PASS_ENDING_ACCESS,
+    D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR, D3D12_RENDER_PASS_ENDING_ACCESS,
     D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE, D3D12_RENDER_PASS_FLAG_NONE,
     D3D12_RENDER_PASS_RENDER_TARGET_DESC, D3D12_VIEWPORT,
 };
@@ -210,7 +210,7 @@ impl FilterPass {
             let pass = [D3D12_RENDER_PASS_RENDER_TARGET_DESC {
                 cpuDescriptor: *output.output.descriptor.as_ref(),
                 BeginningAccess: D3D12_RENDER_PASS_BEGINNING_ACCESS {
-                    Type: D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD,
+                    Type: D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR,
                     ..Default::default()
                 },
                 EndingAccess: D3D12_RENDER_PASS_ENDING_ACCESS {
@@ -219,11 +219,13 @@ impl FilterPass {
                 },
             }];
 
+            /*
             cmd.ClearRenderTargetView(
                 *output.output.descriptor.as_ref(),
                 &[0.0, 0.0, 0.0, 0.0],
                 None,
             );
+            */
 
             cmd.BeginRenderPass(Some(&pass), None, D3D12_RENDER_PASS_FLAG_NONE)
         }
@@ -241,8 +243,8 @@ impl FilterPass {
             cmd.RSSetScissorRects(&[RECT {
                 left: output.x as i32,
                 top: output.y as i32,
-                right: output.size.width as i32,
-                bottom: output.size.height as i32,
+                right: output.size.width as i32 + output.x as i32,
+                bottom: output.size.height as i32 + output.y as i32,
             }]);
 
             parent.draw_quad.draw_quad(&cmd, vbo_type)

--- a/librashader-runtime-d3d12/src/filter_pass.rs
+++ b/librashader-runtime-d3d12/src/filter_pass.rs
@@ -209,7 +209,7 @@ impl FilterPass {
 
         let cmd = cmd.cast::<ID3D12GraphicsCommandList4>()?;
 
-        // Define the clear color
+        // Define the clear color here instead of ClearRenderTargetView
         let clear_value = D3D12_CLEAR_VALUE {
             Format: output.output.format,
             Anonymous: D3D12_CLEAR_VALUE_0 {
@@ -233,17 +233,7 @@ impl FilterPass {
                     Anonymous: Default::default(),
                 },
             }];
-
-            // This isn't compatible with TYPE_DISCARD and shouldn't be used
-            // May work with PRESERVED, but for optimized clear use param above
-            /*
-            cmd.ClearRenderTargetView(
-                *output.output.descriptor.as_ref(),
-                &[0.0, 0.0, 0.0, 0.0],
-                None,
-            );
-            */
-
+            
             cmd.BeginRenderPass(Some(&pass), None, D3D12_RENDER_PASS_FLAG_NONE)
         }
 


### PR DESCRIPTION
I had clipping issues trying to do 4:3 rendering with a custom viewport when using the d3d12 runtime.  I believe this is due to the scissor call not taking the offsets into account for right/bottom.

I also noticed a rainbow/corruption effect in the borders, I'm able to workaround this by switching the `BeginningAccess` type to `D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_CLEAR` but welcome feedback as to whether either of these fixes are appropriate.