### PR TITLE
rt(vk): Dispose created image views in Vulkan

### DIFF
--- a/librashader-runtime-vk/src/filter_chain.rs
+++ b/librashader-runtime-vk/src/filter_chain.rs
@@ -219,6 +219,10 @@ impl FrameResiduals {
         self.image_views.push(output_framebuffer.image_view);
     }
 
+    pub(crate) fn dispose_image_view(&mut self, image_view: vk::ImageView) {
+        self.image_views.push(image_view);
+    }
+
     pub(crate) fn dispose_owned(&mut self, owned: OwnedImage) {
         self.owned.push(owned)
     }
@@ -881,6 +885,8 @@ impl FilterChainVulkan {
             intermediates.dispose_outputs(output_image);
             intermediates.dispose_framebuffers(residual_fb);
         }
+
+        intermediates.dispose_image_view(original_image_view);
 
         self.push_history(input, cmd)?;
         self.common.internal_frame_count = self.common.internal_frame_count.wrapping_add(1);


### PR DESCRIPTION
The Vulkan runtime creates `vkImageView` for the input image so we can use it as a color attachment. This is fine and cheap on normal Vulkan drivers.

In MoltenVK, this creates a new MVKImageView + MTLTexture for each `vkImageView`. This never gets destroyed causing a memory leak.

Fixes #226 